### PR TITLE
fix link to the getting started collab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install datafog
 
 ### Usage
 
-The [Getting Started notebook](/datafog-python/examples/getting_started.ipynb) features a standalone Colab notebook.
+The [Getting Started notebook](/examples/getting_started.ipynb) features a standalone Colab notebook.
 
 #### Text PII Annotation
 


### PR DESCRIPTION
Remove extra "/datafog_python" from the path to the getting started collab notebook.

This change can be verified by browsing the code of this branch in github and testing that the link works