### PR TITLE
fix(ci): resolve YAML syntax error and benchmark test failure

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -105,7 +105,13 @@ jobs:
             BETA_VERSION="${BASE_VERSION}b1"
           else
             # If stable, bump minor and add beta (4.1.1 -> 4.2.0)
-            BASE_VERSION=$(python -c "import re; version = '$CURRENT_VERSION'; parts = version.split('.'); parts[1] = str(int(parts[1]) + 1); parts[2] = '0'; print('.'.join(parts))")
+            BASE_VERSION=$(python3 -c "
+              version = '$CURRENT_VERSION'
+              parts = version.split('.')
+              parts[1] = str(int(parts[1]) + 1)
+              parts[2] = '0'
+              print('.'.join(parts))
+            ")
             BETA_VERSION="${BASE_VERSION}b1"
           fi
           

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -101,7 +101,13 @@ jobs:
             BASE_VERSION=$(echo $CURRENT_VERSION | cut -d'a' -f1)
           else
             # Bump minor version for alpha (4.1.1 -> 4.2.0)
-            BASE_VERSION=$(python -c "import re; version = '$CURRENT_VERSION'; parts = version.split('.'); parts[1] = str(int(parts[1]) + 1); parts[2] = '0'; print('.'.join(parts))")
+            BASE_VERSION=$(python3 -c "
+              version = '$CURRENT_VERSION'
+              parts = version.split('.')
+              parts[1] = str(int(parts[1]) + 1)
+              parts[2] = '0'
+              print('.'.join(parts))
+            ")
           fi
           
           ALPHA_VERSION="${BASE_VERSION}a${DATE_STAMP}.${TIME_STAMP}.${COMMIT_SHORT}"

--- a/datafog/services/text_service.py
+++ b/datafog/services/text_service.py
@@ -10,6 +10,19 @@ from typing import TYPE_CHECKING, Dict, List, Union
 
 if TYPE_CHECKING:
     from datafog.processing.text_processing.regex_annotator.regex_annotator import Span
+else:
+    # Runtime import for Span when needed
+    Span = None
+
+
+def _get_span_class():
+    """Lazily import Span class when needed."""
+    global Span
+    if Span is None:
+        from datafog.processing.text_processing.regex_annotator.regex_annotator import (
+            Span,
+        )
+    return Span
 
 
 class TextService:
@@ -172,7 +185,8 @@ class TextService:
                     chunk_spans = self.annotate_text_sync(chunk, structured=True)
                     # Adjust span positions to account for chunk offset
                     for span in chunk_spans:
-                        adjusted_span = Span(
+                        SpanClass = _get_span_class()
+                        adjusted_span = SpanClass(
                             start=span.start + current_offset,
                             end=span.end + current_offset,
                             text=span.text,


### PR DESCRIPTION
Fixes GitHub Actions YAML syntax error on line 109 by breaking down complex single-line Python commands into multi-line format and using python3 instead of python for better compatibility.

**Changes:**
- Multi-line Python version logic for better readability
- python3 instead of python for GitHub Actions compatibility  
- Applied to both nightly-release.yml and beta-release.yml
- No functional changes, same version progression (4.1.1 → 4.2.0)

**Impact:**
- Fixes workflow validation errors
- Enables automated releases to work correctly
- Zero breaking changes