### PR TITLE
fix(ci): remove indentation from Python code in workflow commands

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -106,12 +106,12 @@ jobs:
           else
             # If stable, bump minor and add beta (4.1.1 -> 4.2.0)
             BASE_VERSION=$(python3 -c "
-              version = '$CURRENT_VERSION'
-              parts = version.split('.')
-              parts[1] = str(int(parts[1]) + 1)
-              parts[2] = '0'
-              print('.'.join(parts))
-            ")
+version = '$CURRENT_VERSION'
+parts = version.split('.')
+parts[1] = str(int(parts[1]) + 1)
+parts[2] = '0'
+print('.'.join(parts))
+")
             BETA_VERSION="${BASE_VERSION}b1"
           fi
           

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -102,12 +102,12 @@ jobs:
           else
             # Bump minor version for alpha (4.1.1 -> 4.2.0)
             BASE_VERSION=$(python3 -c "
-              version = '$CURRENT_VERSION'
-              parts = version.split('.')
-              parts[1] = str(int(parts[1]) + 1)
-              parts[2] = '0'
-              print('.'.join(parts))
-            ")
+version = '$CURRENT_VERSION'
+parts = version.split('.')
+parts[1] = str(int(parts[1]) + 1)
+parts[2] = '0'
+print('.'.join(parts))
+")
           fi
           
           ALPHA_VERSION="${BASE_VERSION}a${DATE_STAMP}.${TIME_STAMP}.${COMMIT_SHORT}"


### PR DESCRIPTION
- Fix IndentationError in multi-line Python commands
- Remove extra spaces from Python code inside shell commands
- Python code at start of line to avoid indentation issues
- Tested locally: 4.1.1 → 4.2.0 version bump works correctly