### PR TITLE
Fix release workflow checks

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Check for changes since last beta release
         id: changes
+        env:
+          FORCE_BUILD: ${{ github.event.inputs.force_build }}
         run: |
           LAST_BETA=$(git tag -l "*b*" --sort=-version:refname | head -n1)
 
@@ -45,7 +47,7 @@ jobs:
           echo "commit_count=$COMMIT_COUNT" >> $GITHUB_OUTPUT
           echo "last_beta=$LAST_BETA" >> $GITHUB_OUTPUT
 
-          if [ "$COMMIT_COUNT" -gt 0 ] || [ "${{ github.event.inputs.force_build == 'true' }}" = "true" ]; then
+          if [ "$COMMIT_COUNT" -gt 0 ] || [ "$FORCE_BUILD" = "true" ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Check for changes since last alpha release
         id: changes
+        env:
+          FORCE_BUILD: ${{ github.event.inputs.force_build }}
         run: |
           LAST_ALPHA=$(git tag -l "*alpha*" --sort=-version:refname | head -n1)
 
@@ -46,7 +48,7 @@ jobs:
           echo "Commits since last alpha: $COMMIT_COUNT"
           echo "commit_count=$COMMIT_COUNT" >> $GITHUB_OUTPUT
 
-          if [ "$COMMIT_COUNT" -gt 0 ] || [ "${{ github.event.inputs.force_build == 'true' }}" = "true" ]; then
+          if [ "$COMMIT_COUNT" -gt 0 ] || [ "$FORCE_BUILD" = "true" ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
             echo "✅ Changes detected, proceeding with nightly build"
           else


### PR DESCRIPTION
## Summary
- handle force_build input via environment variable in beta release workflow
- same fix for nightly release workflow

## Testing
- `python -m pytest` *(fails: 11 errors during collection)*