### PR TITLE
feat(telemetry): add anonymous opt-out PostHog telemetry

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,12 +1,18 @@
 [run]
 source = datafog
-omit = 
+omit =
     */tests/*
     */test_*
     */__pycache__/*
     */venv/*
     */env/*
     setup.py
+    datafog/__init___lean.py
+    datafog/__init___original.py
+    datafog/main_lean.py
+    datafog/main_original.py
+    datafog/services/text_service_lean.py
+    datafog/services/text_service_original.py
 
 [report]
 exclude_lines =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y tesseract-ocr libtesseract-dev
 
-      - name: Install minimal dependencies to prevent segfault
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" 
+          pip install -e ".[dev]"
           pip install -r requirements-dev.txt
-          # Add only safe extras that don't include heavy ML dependencies
-          pip install -e ".[cli]"
+          pip install -e ".[nlp,cli]"
+          pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1.tar.gz
 
       - name: Run test suite (ignore segfault during cleanup)
         run: |
@@ -86,9 +86,9 @@ jobs:
               exit(1)
           "
           
-      - name: Run coverage on core modules only  
+      - name: Run coverage
         run: |
-          python -m pytest tests/test_text_service.py tests/test_regex_annotator.py tests/test_anonymizer.py --cov=datafog --cov-report=xml --cov-config=.coveragerc
+          python -m pytest tests/ -v --ignore=tests/test_gliner_annotator.py --cov=datafog --cov-report=xml --cov-config=.coveragerc
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -294,6 +294,29 @@ async def redact_pii_middleware(request, call_next):
 
 ---
 
+## Privacy & Telemetry
+
+DataFog collects **anonymous** usage telemetry to help us understand which features are used and prioritize development. This data contains:
+
+- Function and engine usage (e.g., "regex" vs "gliner")
+- Coarse performance buckets (e.g., "10-100ms"), never exact timings
+- Error class names only (e.g., "ImportError"), never error messages or stack traces
+- A one-way hashed machine identifier — no IP addresses, usernames, or file paths
+
+**No text content, PII, or personally identifiable information is ever collected.**
+
+To opt out, set either environment variable before running DataFog:
+
+```bash
+export DATAFOG_NO_TELEMETRY=1
+# or
+export DO_NOT_TRACK=1
+```
+
+Telemetry uses only Python's standard library (`urllib.request`) — no additional dependencies are installed. All sends are fire-and-forget in background threads and will never affect performance or raise exceptions.
+
+---
+
 ## Common Use Cases
 
 ### Enterprise

--- a/datafog/__init__.py
+++ b/datafog/__init__.py
@@ -149,6 +149,11 @@ def detect(text: str) -> list:
         >>> detect("Contact john@example.com")
         [{'type': 'EMAIL', 'value': 'john@example.com', 'start': 8, 'end': 24}]
     """
+    import time as _time
+
+    _start = _time.monotonic()
+
+    _lazy_import_regex_annotator()
     annotator = RegexAnnotator()
     # Use the structured output to get proper positions
     _, result = annotator.annotate_with_spans(text)
@@ -165,6 +170,27 @@ def detect(text: str) -> list:
                     "end": span.end,
                 }
             )
+
+    try:
+        from .telemetry import (
+            _get_duration_bucket,
+            _get_text_length_bucket,
+            track_function_call,
+        )
+
+        _duration = (_time.monotonic() - _start) * 1000
+        entity_types = list({e["type"] for e in entities})
+        track_function_call(
+            function_name="detect",
+            module="datafog",
+            engine="regex",
+            text_length_bucket=_get_text_length_bucket(len(text)),
+            entity_count=len(entities),
+            entity_types_found=entity_types,
+            duration_ms_bucket=_get_duration_bucket(_duration),
+        )
+    except Exception:
+        pass
 
     return entities
 
@@ -190,6 +216,10 @@ def process(text: str, anonymize: bool = False, method: str = "redact") -> dict:
             'findings': [{'type': 'EMAIL', 'value': 'john@example.com', ...}]
         }
     """
+    import time as _time
+
+    _start = _time.monotonic()
+
     findings = detect(text)
 
     result = {"original": text, "findings": findings}
@@ -215,6 +245,21 @@ def process(text: str, anonymize: bool = False, method: str = "redact") -> dict:
             anonymized = anonymized[:start] + replacement + anonymized[end:]
 
         result["anonymized"] = anonymized
+
+    try:
+        from .telemetry import _get_duration_bucket, track_function_call
+
+        _duration = (_time.monotonic() - _start) * 1000
+        track_function_call(
+            function_name="process",
+            module="datafog",
+            anonymize=anonymize,
+            method=method,
+            entity_count=len(findings),
+            duration_ms_bucket=_get_duration_bucket(_duration),
+        )
+    except Exception:
+        pass
 
     return result
 

--- a/datafog/client.py
+++ b/datafog/client.py
@@ -48,8 +48,26 @@ def scan_image(
     try:
         results = asyncio.run(ocr_client.run_ocr_pipeline(image_urls=image_urls))
         typer.echo(f"OCR Pipeline Results: {results}")
+
+        try:
+            from .telemetry import track_function_call
+
+            track_function_call(
+                function_name="scan_image",
+                module="datafog.client",
+                source="cli",
+                batch_size=len(image_urls),
+            )
+        except Exception:
+            pass
     except Exception as e:
         logging.exception("Error in run_ocr_pipeline")
+        try:
+            from .telemetry import track_error
+
+            track_error("scan_image", type(e).__name__, source="cli")
+        except Exception:
+            pass
         typer.echo(f"Error: {str(e)}", err=True)
         raise typer.Exit(code=1)
 
@@ -83,8 +101,27 @@ def scan_text(
     try:
         results = text_client.run_text_pipeline_sync(str_list=str_list)
         typer.echo(f"Text Pipeline Results: {results}")
+
+        try:
+            from .telemetry import track_function_call
+
+            track_function_call(
+                function_name="scan_text",
+                module="datafog.client",
+                source="cli",
+                batch_size=len(str_list),
+                operations=[op.value for op in operation_list],
+            )
+        except Exception:
+            pass
     except Exception as e:
         logging.exception("Text pipeline error")
+        try:
+            from .telemetry import track_error
+
+            track_error("scan_text", type(e).__name__, source="cli")
+        except Exception:
+            pass
         typer.echo(f"Error: {str(e)}", err=True)
         raise typer.Exit(code=1)
 
@@ -245,6 +282,18 @@ def redact_text(text: str = typer.Argument(None, help="Text to redact")):
     result = anonymizer.anonymize(text, annotations)
     typer.echo(result.anonymized_text)
 
+    try:
+        from .telemetry import track_function_call
+
+        track_function_call(
+            function_name="redact_text",
+            module="datafog.client",
+            source="cli",
+            method="redact",
+        )
+    except Exception:
+        pass
+
 
 @app.command()
 def replace_text(text: str = typer.Argument(None, help="Text to replace PII")):
@@ -265,6 +314,18 @@ def replace_text(text: str = typer.Argument(None, help="Text to replace PII")):
     annotations = annotator.annotate_text(text)
     result = anonymizer.anonymize(text, annotations)
     typer.echo(result.anonymized_text)
+
+    try:
+        from .telemetry import track_function_call
+
+        track_function_call(
+            function_name="replace_text",
+            module="datafog.client",
+            source="cli",
+            method="replace",
+        )
+    except Exception:
+        pass
 
 
 @app.command()
@@ -290,6 +351,19 @@ def hash_text(
     annotations = annotator.annotate_text(text)
     result = anonymizer.anonymize(text, annotations)
     typer.echo(result.anonymized_text)
+
+    try:
+        from .telemetry import track_function_call
+
+        track_function_call(
+            function_name="hash_text",
+            module="datafog.client",
+            source="cli",
+            method="hash",
+            hash_type=hash_type.value,
+        )
+    except Exception:
+        pass
 
 
 if __name__ == "__main__":

--- a/datafog/core.py
+++ b/datafog/core.py
@@ -30,6 +30,10 @@ def detect_pii(text: str) -> Dict[str, List[str]]:
         >>> print(result)
         {'EMAIL': ['john@example.com'], 'PHONE': ['(555) 123-4567']}
     """
+    import time as _time
+
+    _start = _time.monotonic()
+
     try:
         from datafog.services.text_service import TextService
 
@@ -46,9 +50,36 @@ def detect_pii(text: str) -> Dict[str, List[str]]:
                     pii_dict[entity_type] = []
                 pii_dict[entity_type].append(annotation.text)
 
+        try:
+            from datafog.telemetry import (
+                _get_duration_bucket,
+                _get_text_length_bucket,
+                track_function_call,
+            )
+
+            _duration = (_time.monotonic() - _start) * 1000
+            entity_count = sum(len(v) for v in pii_dict.values())
+            track_function_call(
+                function_name="detect_pii",
+                module="datafog.core",
+                engine="regex",
+                text_length_bucket=_get_text_length_bucket(len(text)),
+                entity_count=entity_count,
+                entity_types_found=list(pii_dict.keys()),
+                duration_ms_bucket=_get_duration_bucket(_duration),
+            )
+        except Exception:
+            pass
+
         return pii_dict
 
     except ImportError as e:
+        try:
+            from datafog.telemetry import track_error
+
+            track_error("detect_pii", type(e).__name__, engine="regex")
+        except Exception:
+            pass
         raise ImportError(
             "Core dependencies missing. Install with: pip install datafog[all]"
         ) from e
@@ -70,6 +101,11 @@ def anonymize_text(text: str, method: Union[str, AnonymizerType] = "redact") -> 
         >>> print(result)
         "Contact [EMAIL_REDACTED]"
     """
+    import time as _time
+
+    _start = _time.monotonic()
+    _method_str = method if isinstance(method, str) else method.value
+
     try:
         from datafog.models.anonymizer import Anonymizer, AnonymizerType
         from datafog.services.text_service import TextService
@@ -109,9 +145,34 @@ def anonymize_text(text: str, method: Union[str, AnonymizerType] = "redact") -> 
         # Create anonymizer and apply
         anonymizer = Anonymizer(anonymizer_type=method)
         result = anonymizer.anonymize(text, annotations)
+
+        try:
+            from datafog.telemetry import (
+                _get_duration_bucket,
+                _get_text_length_bucket,
+                track_function_call,
+            )
+
+            _duration = (_time.monotonic() - _start) * 1000
+            track_function_call(
+                function_name="anonymize_text",
+                module="datafog.core",
+                method=_method_str,
+                text_length_bucket=_get_text_length_bucket(len(text)),
+                duration_ms_bucket=_get_duration_bucket(_duration),
+            )
+        except Exception:
+            pass
+
         return result.anonymized_text
 
     except ImportError as e:
+        try:
+            from datafog.telemetry import track_error
+
+            track_error("anonymize_text", type(e).__name__, method=_method_str)
+        except Exception:
+            pass
         raise ImportError(
             "Core dependencies missing. Install with: pip install datafog[all]"
         ) from e
@@ -139,12 +200,28 @@ def scan_text(
         >>> print(entities)
         {'EMAIL': ['john@example.com']}
     """
+    import time as _time
+
+    _start = _time.monotonic()
+
     entities = detect_pii(text)
 
-    if return_entities:
-        return entities
-    else:
-        return len(entities) > 0
+    result = entities if return_entities else len(entities) > 0
+
+    try:
+        from datafog.telemetry import _get_duration_bucket, track_function_call
+
+        _duration = (_time.monotonic() - _start) * 1000
+        track_function_call(
+            function_name="scan_text",
+            module="datafog.core",
+            return_entities=return_entities,
+            duration_ms_bucket=_get_duration_bucket(_duration),
+        )
+    except Exception:
+        pass
+
+    return result
 
 
 def get_supported_entities() -> List[str]:
@@ -165,7 +242,19 @@ def get_supported_entities() -> List[str]:
         )
 
         annotator = RegexAnnotator()
-        return [entity.value for entity in annotator.supported_entities]
+        result = [entity.value for entity in annotator.supported_entities]
+
+        try:
+            from datafog.telemetry import track_function_call
+
+            track_function_call(
+                function_name="get_supported_entities",
+                module="datafog.core",
+            )
+        except Exception:
+            pass
+
+        return result
 
     except ImportError:
         # Fallback to basic list if imports fail

--- a/datafog/main.py
+++ b/datafog/main.py
@@ -50,6 +50,19 @@ class DataFog:
         self.logger.info(f"Hash Type: {hash_type}")
         self.logger.info(f"Anonymizer Type: {anonymizer_type}")
 
+        try:
+            from .telemetry import track_function_call
+
+            track_function_call(
+                function_name="DataFog.__init__",
+                module="datafog.main",
+                operations=[op.value for op in operations],
+                hash_type=hash_type.value,
+                anonymizer_type=anonymizer_type.value,
+            )
+        except Exception:
+            pass
+
     def run_text_pipeline_sync(self, str_list: List[str]) -> List[str]:
         """
         Run the text pipeline synchronously on a list of input text.
@@ -63,6 +76,9 @@ class DataFog:
         Raises:
             Exception: Any error encountered during the text processing.
         """
+        import time as _time
+
+        _start = _time.monotonic()
         try:
             self.logger.info(f"Starting text pipeline with {len(str_list)} texts.")
             if OperationType.SCAN in self.operations:
@@ -115,16 +131,42 @@ class DataFog:
                         )
                         anonymized_results.append(anonymized_result.anonymized_text)
 
-                    return anonymized_results
+                    _pipeline_result = anonymized_results
                 else:
-                    return annotated_text
+                    _pipeline_result = annotated_text
+            else:
+                self.logger.info(
+                    "No annotation or anonymization operation found; returning original texts."
+                )
+                _pipeline_result = str_list
 
-            self.logger.info(
-                "No annotation or anonymization operation found; returning original texts."
-            )
-            return str_list
+            try:
+                from .telemetry import _get_duration_bucket, track_function_call
+
+                _duration = (_time.monotonic() - _start) * 1000
+                track_function_call(
+                    function_name="DataFog.run_text_pipeline_sync",
+                    module="datafog.main",
+                    batch_size=len(str_list),
+                    operations=[op.value for op in self.operations],
+                    duration_ms_bucket=_get_duration_bucket(_duration),
+                )
+            except Exception:
+                pass
+
+            return _pipeline_result
         except Exception as e:
             self.logger.error(f"Error in run_text_pipeline_sync: {str(e)}")
+            try:
+                from .telemetry import track_error
+
+                track_error(
+                    "DataFog.run_text_pipeline_sync",
+                    type(e).__name__,
+                    engine="regex",
+                )
+            except Exception:
+                pass
             raise
 
     def detect(self, text: str) -> dict:
@@ -137,7 +179,32 @@ class DataFog:
         Returns:
             Dictionary mapping entity types to lists of found entities
         """
-        return self.regex_annotator.annotate(text)
+        import time as _time
+
+        _start = _time.monotonic()
+
+        result = self.regex_annotator.annotate(text)
+
+        try:
+            from .telemetry import (
+                _get_duration_bucket,
+                _get_text_length_bucket,
+                track_function_call,
+            )
+
+            _duration = (_time.monotonic() - _start) * 1000
+            entity_count = sum(len(v) for v in result.values())
+            track_function_call(
+                function_name="DataFog.detect",
+                module="datafog.main",
+                text_length_bucket=_get_text_length_bucket(len(text)),
+                entity_count=entity_count,
+                duration_ms_bucket=_get_duration_bucket(_duration),
+            )
+        except Exception:
+            pass
+
+        return result
 
     def process(
         self, text: str, anonymize: bool = False, method: str = "redact"
@@ -153,6 +220,10 @@ class DataFog:
         Returns:
             Dictionary with original text, anonymized text (if requested), and findings
         """
+        import time as _time
+
+        _start = _time.monotonic()
+
         annotations_dict = self.detect(text)
 
         result = {"original": text, "findings": annotations_dict}
@@ -192,6 +263,20 @@ class DataFog:
             )
             anonymized_result = temp_anonymizer.anonymize(text, annotation_results)
             result["anonymized"] = anonymized_result.anonymized_text
+
+        try:
+            from .telemetry import _get_duration_bucket, track_function_call
+
+            _duration = (_time.monotonic() - _start) * 1000
+            track_function_call(
+                function_name="DataFog.process",
+                module="datafog.main",
+                anonymize=anonymize,
+                method=method,
+                duration_ms_bucket=_get_duration_bucket(_duration),
+            )
+        except Exception:
+            pass
 
         return result
 

--- a/datafog/services/__init__.py
+++ b/datafog/services/__init__.py
@@ -1,5 +1,13 @@
-from .image_service import ImageService
-from .spark_service import SparkService
+try:
+    from .image_service import ImageService
+except ImportError:
+    ImageService = None
+
+try:
+    from .spark_service import SparkService
+except ImportError:
+    SparkService = None
+
 from .text_service import TextService
 
 __all__ = ["ImageService", "SparkService", "TextService"]

--- a/datafog/services/text_service.py
+++ b/datafog/services/text_service.py
@@ -80,6 +80,19 @@ class TextService:
         elif engine == "smart":
             self._ensure_gliner_available()  # Smart mode requires GLiNER
 
+        try:
+            from datafog.telemetry import track_function_call
+
+            track_function_call(
+                function_name="TextService.__init__",
+                module="datafog.services.text_service",
+                engine=engine,
+                text_chunk_length=text_chunk_length,
+                gliner_model=gliner_model if engine in ("gliner", "smart") else None,
+            )
+        except Exception:
+            pass
+
     @property
     def regex_annotator(self):
         """Lazy-loaded regex annotator."""
@@ -345,17 +358,42 @@ class TextService:
         Returns:
             Dictionary mapping entity types to lists of entities, or list of Span objects
         """
+        import time as _time
+
+        _start = _time.monotonic()
+
         if len(text) <= self.text_chunk_length:
             # Single chunk processing
-            return self._annotate_single_chunk(text, structured)
+            result = self._annotate_single_chunk(text, structured)
         else:
             # Multi-chunk processing
             chunks = self._chunk_text(text)
 
             if structured:
-                return self._annotate_multiple_chunks_structured(chunks)
+                result = self._annotate_multiple_chunks_structured(chunks)
             else:
-                return self._annotate_multiple_chunks_dict(chunks)
+                result = self._annotate_multiple_chunks_dict(chunks)
+
+        try:
+            from datafog.telemetry import (
+                _get_duration_bucket,
+                _get_text_length_bucket,
+                track_function_call,
+            )
+
+            _duration = (_time.monotonic() - _start) * 1000
+            track_function_call(
+                function_name="TextService.annotate_text_sync",
+                module="datafog.services.text_service",
+                engine=self.engine,
+                text_length_bucket=_get_text_length_bucket(len(text)),
+                structured=structured,
+                duration_ms_bucket=_get_duration_bucket(_duration),
+            )
+        except Exception:
+            pass
+
+        return result
 
     async def annotate_text_async(
         self, text: str, structured: bool = False

--- a/datafog/telemetry.py
+++ b/datafog/telemetry.py
@@ -1,0 +1,275 @@
+"""
+Anonymous, opt-out usage telemetry for DataFog.
+
+Collects anonymous usage data to help the DataFog team understand which engines,
+functions, and features are actually used. No text content is ever sent.
+
+Opt out by setting either environment variable:
+    DATAFOG_NO_TELEMETRY=1
+    DO_NOT_TRACK=1
+"""
+
+import hashlib
+import json
+import os
+import platform
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+_POSTHOG_API_KEY = "phc_niGZ03Ey0ta6UzkCMtiHF0TdurLu2E3AVjyzQJRgpch"
+_POSTHOG_HOST = "https://us.i.posthog.com"
+
+_initialized = False
+_init_lock = threading.Lock()
+_anonymous_id = None
+
+# Thread-local scope for deduplication across nested calls
+_scope = threading.local()
+
+
+def _is_telemetry_enabled() -> bool:
+    """Check if telemetry is enabled (opt-out via env vars)."""
+    if os.environ.get("DATAFOG_NO_TELEMETRY", "").strip() == "1":
+        return False
+    if os.environ.get("DO_NOT_TRACK", "").strip() == "1":
+        return False
+    return True
+
+
+def _get_anonymous_id() -> str:
+    """Get or create a deterministic anonymous ID based on machine info.
+
+    The ID is a SHA-256 hash of machine-specific information, persisted
+    to ~/.datafog/.telemetry_id for consistency across sessions.
+    No PII is stored or transmitted.
+    """
+    global _anonymous_id
+    if _anonymous_id is not None:
+        return _anonymous_id
+
+    telemetry_dir = Path.home() / ".datafog"
+    telemetry_file = telemetry_dir / ".telemetry_id"
+
+    # Try to read persisted ID
+    try:
+        if telemetry_file.exists():
+            stored_id = telemetry_file.read_text().strip()
+            if stored_id:
+                _anonymous_id = stored_id
+                return _anonymous_id
+    except Exception:
+        pass
+
+    # Generate deterministic ID from machine info
+    machine_info = f"{platform.node()}-{platform.machine()}-{os.getuid() if hasattr(os, 'getuid') else 'nouid'}"
+    _anonymous_id = hashlib.sha256(machine_info.encode()).hexdigest()
+
+    # Persist to disk
+    try:
+        telemetry_dir.mkdir(parents=True, exist_ok=True)
+        telemetry_file.write_text(_anonymous_id)
+    except Exception:
+        pass
+
+    return _anonymous_id
+
+
+def _get_text_length_bucket(length: int) -> str:
+    """Convert exact text length to a privacy-safe bucket."""
+    if length == 0:
+        return "0"
+    elif length <= 100:
+        return "1-100"
+    elif length <= 1000:
+        return "100-1k"
+    elif length <= 10000:
+        return "1k-10k"
+    elif length <= 100000:
+        return "10k-100k"
+    else:
+        return "100k+"
+
+
+def _get_duration_bucket(duration_ms: float) -> str:
+    """Convert exact duration to a coarse bucket."""
+    if duration_ms <= 10:
+        return "0-10"
+    elif duration_ms <= 100:
+        return "10-100"
+    elif duration_ms <= 1000:
+        return "100-1000"
+    else:
+        return "1000+"
+
+
+def _detect_installed_extras() -> list:
+    """Probe which optional extras are installed."""
+    extras = []
+
+    try:
+        import spacy  # noqa: F401
+
+        extras.append("nlp")
+    except ImportError:
+        pass
+
+    try:
+        import gliner  # noqa: F401
+
+        extras.append("nlp-advanced")
+    except ImportError:
+        pass
+
+    try:
+        import pytesseract  # noqa: F401
+
+        extras.append("ocr")
+    except ImportError:
+        pass
+
+    try:
+        import typer  # noqa: F401
+
+        extras.append("cli")
+    except ImportError:
+        pass
+
+    try:
+        import pyspark  # noqa: F401
+
+        extras.append("distributed")
+    except ImportError:
+        pass
+
+    return extras
+
+
+def _detect_ci() -> bool:
+    """Check if running in a CI environment."""
+    ci_vars = [
+        "CI",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "CIRCLECI",
+        "TRAVIS",
+        "JENKINS_URL",
+        "BUILDKITE",
+        "TF_BUILD",
+        "CODEBUILD_BUILD_ID",
+    ]
+    return any(os.environ.get(v) for v in ci_vars)
+
+
+def _send_event(event_name: str, properties: dict) -> None:
+    """POST event to PostHog /capture/ endpoint in a daemon thread.
+
+    Fire-and-forget: failures are silently ignored.
+    """
+    if not _is_telemetry_enabled():
+        return
+
+    def _post():
+        try:
+            payload = json.dumps(
+                {
+                    "api_key": _POSTHOG_API_KEY,
+                    "event": event_name,
+                    "properties": {
+                        "distinct_id": _get_anonymous_id(),
+                        **properties,
+                    },
+                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime()),
+                }
+            ).encode("utf-8")
+
+            req = urllib.request.Request(
+                f"{_POSTHOG_HOST}/capture/",
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            urllib.request.urlopen(req, timeout=5)
+        except Exception:
+            pass
+
+    t = threading.Thread(target=_post, daemon=True)
+    t.start()
+
+
+def _ensure_initialized() -> None:
+    """Send datafog_init event once per process, thread-safe."""
+    global _initialized
+    if _initialized:
+        return
+
+    with _init_lock:
+        if _initialized:
+            return
+        _initialized = True
+
+    if not _is_telemetry_enabled():
+        return
+
+    try:
+        from .__about__ import __version__
+    except Exception:
+        __version__ = "unknown"
+
+    uname = platform.uname()
+    _send_event(
+        "datafog_init",
+        {
+            "package_version": __version__,
+            "python_version": platform.python_version(),
+            "os": uname.system,
+            "os_version": uname.release,
+            "arch": uname.machine,
+            "installed_extras": _detect_installed_extras(),
+            "is_ci": _detect_ci(),
+        },
+    )
+
+
+def track_function_call(function_name: str, module: str, **kwargs) -> None:
+    """Track a public API function call.
+
+    Uses thread-local scope to deduplicate nested calls (e.g., process()
+    calling detect()). Only the outermost call is tracked.
+    """
+    if not _is_telemetry_enabled():
+        return
+
+    # Deduplication: skip if already inside a tracked scope
+    if getattr(_scope, "active", False):
+        return
+
+    _scope.active = True
+    try:
+        _ensure_initialized()
+        properties = {
+            "function": function_name,
+            "module": module,
+        }
+        properties.update(kwargs)
+        _send_event("datafog_function_called", properties)
+    finally:
+        _scope.active = False
+
+
+def track_error(function_name: str, error_type: str, **kwargs) -> None:
+    """Track an error in a public API function.
+
+    Only sends the error class name, never the message (could contain PII).
+    """
+    if not _is_telemetry_enabled():
+        return
+
+    _ensure_initialized()
+    properties = {
+        "function": function_name,
+        "error_type": error_type,
+    }
+    properties.update(kwargs)
+    _send_event("datafog_error", properties)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,569 @@
+"""Tests for datafog.telemetry module."""
+
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_telemetry_state():
+    """Reset telemetry module-level state between tests."""
+    import datafog.telemetry as tel
+
+    tel._initialized = False
+    tel._anonymous_id = None
+    # Reset thread-local scope
+    if hasattr(tel._scope, "active"):
+        del tel._scope.active
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    """Ensure clean telemetry state for every test and disable network."""
+    _reset_telemetry_state()
+    # Default: telemetry enabled but network mocked
+    monkeypatch.delenv("DATAFOG_NO_TELEMETRY", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    yield
+    _reset_telemetry_state()
+
+
+@pytest.fixture
+def mock_urlopen():
+    """Mock urllib.request.urlopen to capture payloads without network."""
+    with patch("datafog.telemetry.urllib.request.urlopen") as m:
+        yield m
+
+
+# ===========================================================================
+# Group 1: Opt-out behaviour
+# ===========================================================================
+
+
+class TestOptOut:
+    def test_datafog_no_telemetry_disables(self, monkeypatch):
+        from datafog.telemetry import _is_telemetry_enabled
+
+        monkeypatch.setenv("DATAFOG_NO_TELEMETRY", "1")
+        assert _is_telemetry_enabled() is False
+
+    def test_do_not_track_disables(self, monkeypatch):
+        from datafog.telemetry import _is_telemetry_enabled
+
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        assert _is_telemetry_enabled() is False
+
+    def test_enabled_by_default(self):
+        from datafog.telemetry import _is_telemetry_enabled
+
+        assert _is_telemetry_enabled() is True
+
+    def test_non_one_value_does_not_disable(self, monkeypatch):
+        from datafog.telemetry import _is_telemetry_enabled
+
+        monkeypatch.setenv("DATAFOG_NO_TELEMETRY", "true")
+        assert _is_telemetry_enabled() is True
+
+    def test_send_event_noop_when_disabled(self, monkeypatch, mock_urlopen):
+        from datafog.telemetry import _send_event
+
+        monkeypatch.setenv("DATAFOG_NO_TELEMETRY", "1")
+        _send_event("test_event", {"key": "value"})
+        time.sleep(0.1)
+        mock_urlopen.assert_not_called()
+
+    def test_track_function_call_noop_when_disabled(self, monkeypatch, mock_urlopen):
+        from datafog.telemetry import track_function_call
+
+        monkeypatch.setenv("DO_NOT_TRACK", "1")
+        track_function_call("test_fn", "test_module")
+        time.sleep(0.1)
+        mock_urlopen.assert_not_called()
+
+
+# ===========================================================================
+# Group 2: Privacy guarantees
+# ===========================================================================
+
+
+class TestPrivacy:
+    def test_text_length_bucket_zero(self):
+        from datafog.telemetry import _get_text_length_bucket
+
+        assert _get_text_length_bucket(0) == "0"
+
+    def test_text_length_bucket_small(self):
+        from datafog.telemetry import _get_text_length_bucket
+
+        assert _get_text_length_bucket(50) == "1-100"
+
+    def test_text_length_bucket_medium(self):
+        from datafog.telemetry import _get_text_length_bucket
+
+        assert _get_text_length_bucket(500) == "100-1k"
+
+    def test_text_length_bucket_large(self):
+        from datafog.telemetry import _get_text_length_bucket
+
+        assert _get_text_length_bucket(5000) == "1k-10k"
+
+    def test_text_length_bucket_very_large(self):
+        from datafog.telemetry import _get_text_length_bucket
+
+        assert _get_text_length_bucket(50000) == "10k-100k"
+
+    def test_text_length_bucket_huge(self):
+        from datafog.telemetry import _get_text_length_bucket
+
+        assert _get_text_length_bucket(500000) == "100k+"
+
+    def test_duration_bucket_fast(self):
+        from datafog.telemetry import _get_duration_bucket
+
+        assert _get_duration_bucket(5) == "0-10"
+
+    def test_duration_bucket_medium(self):
+        from datafog.telemetry import _get_duration_bucket
+
+        assert _get_duration_bucket(50) == "10-100"
+
+    def test_duration_bucket_slow(self):
+        from datafog.telemetry import _get_duration_bucket
+
+        assert _get_duration_bucket(500) == "100-1000"
+
+    def test_duration_bucket_very_slow(self):
+        from datafog.telemetry import _get_duration_bucket
+
+        assert _get_duration_bucket(5000) == "1000+"
+
+    def test_anonymous_id_is_sha256(self, tmp_path, monkeypatch):
+        import datafog.telemetry as tel
+
+        tel._anonymous_id = None
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        anon_id = tel._get_anonymous_id()
+        # Should be 64 hex characters (SHA-256)
+        assert len(anon_id) == 64
+        assert all(c in "0123456789abcdef" for c in anon_id)
+
+    def test_anonymous_id_persisted(self, tmp_path, monkeypatch):
+        import datafog.telemetry as tel
+
+        tel._anonymous_id = None
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        id1 = tel._get_anonymous_id()
+
+        # Reset in-memory cache, should read from file
+        tel._anonymous_id = None
+        id2 = tel._get_anonymous_id()
+        assert id1 == id2
+
+    def test_payload_never_contains_text_content(self, mock_urlopen):
+        """Verify that tracked events don't leak text content."""
+        from datafog.telemetry import track_function_call
+
+        track_function_call(
+            "detect",
+            "datafog",
+            text_length_bucket="1-100",
+            entity_count=2,
+        )
+        # Wait for daemon thread
+        time.sleep(0.3)
+
+        if mock_urlopen.called:
+            call_args = mock_urlopen.call_args
+            req = call_args[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            props = body["properties"]
+            # Must not contain any raw text
+            for key, value in props.items():
+                if isinstance(value, str):
+                    assert "example.com" not in value
+                    assert "@" not in value or key == "distinct_id"
+
+
+# ===========================================================================
+# Group 3: Non-blocking behaviour
+# ===========================================================================
+
+
+class TestNonBlocking:
+    def test_send_event_returns_immediately(self, mock_urlopen):
+        from datafog.telemetry import _send_event
+
+        # Make urlopen block
+        mock_urlopen.side_effect = lambda *a, **k: time.sleep(10)
+
+        start = time.monotonic()
+        _send_event("test", {"k": "v"})
+        elapsed = time.monotonic() - start
+
+        # Should return in <100ms even though urlopen blocks for 10s
+        assert elapsed < 0.1
+
+    def test_track_function_call_returns_immediately(self, mock_urlopen):
+        from datafog.telemetry import track_function_call
+
+        mock_urlopen.side_effect = lambda *a, **k: time.sleep(10)
+
+        start = time.monotonic()
+        track_function_call("fn", "mod")
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.1
+
+    def test_network_failure_is_silent(self, mock_urlopen):
+        from datafog.telemetry import track_function_call
+
+        mock_urlopen.side_effect = Exception("Network down")
+        # Should not raise
+        track_function_call("fn", "mod")
+        time.sleep(0.3)
+
+    def test_urlopen_timeout_is_bounded(self, mock_urlopen):
+        """Verify we pass a timeout to urlopen."""
+        from datafog.telemetry import _send_event
+
+        _send_event("test", {})
+        time.sleep(0.3)
+
+        if mock_urlopen.called:
+            call_args = mock_urlopen.call_args
+            assert call_args[1].get("timeout", None) is not None
+            assert call_args[1]["timeout"] <= 10
+
+
+# ===========================================================================
+# Group 4: Payload correctness
+# ===========================================================================
+
+
+class TestPayloadCorrectness:
+    def test_init_event_sent_once(self, mock_urlopen):
+        from datafog.telemetry import _ensure_initialized
+
+        _ensure_initialized()
+        _ensure_initialized()
+        _ensure_initialized()
+        time.sleep(0.3)
+
+        # Should only create one thread/call for init
+        assert mock_urlopen.call_count <= 1
+
+    def test_init_event_has_required_properties(self, mock_urlopen):
+        from datafog.telemetry import _ensure_initialized
+
+        _ensure_initialized()
+        time.sleep(0.3)
+
+        assert mock_urlopen.called
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+
+        assert body["event"] == "datafog_init"
+        assert body["api_key"] == "phc_niGZ03Ey0ta6UzkCMtiHF0TdurLu2E3AVjyzQJRgpch"
+        props = body["properties"]
+        assert "package_version" in props
+        assert "python_version" in props
+        assert "os" in props
+        assert "os_version" in props
+        assert "arch" in props
+        assert "installed_extras" in props
+        assert "is_ci" in props
+        assert "distinct_id" in props
+
+    def test_function_call_event_properties(self, mock_urlopen):
+        from datafog.telemetry import track_function_call
+
+        track_function_call(
+            "detect",
+            "datafog",
+            engine="regex",
+            text_length_bucket="1-100",
+            entity_count=3,
+        )
+        time.sleep(0.3)
+
+        # Find the function_called event (init event may also be present)
+        found = False
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            if body["event"] == "datafog_function_called":
+                props = body["properties"]
+                assert props["function"] == "detect"
+                assert props["module"] == "datafog"
+                assert props["engine"] == "regex"
+                assert props["text_length_bucket"] == "1-100"
+                assert props["entity_count"] == 3
+                found = True
+        assert found, "datafog_function_called event not found"
+
+    def test_error_event_properties(self, mock_urlopen):
+        from datafog.telemetry import track_error
+
+        track_error("detect", "ValueError", engine="regex")
+        time.sleep(0.3)
+
+        found = False
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            if body["event"] == "datafog_error":
+                props = body["properties"]
+                assert props["function"] == "detect"
+                assert props["error_type"] == "ValueError"
+                assert props["engine"] == "regex"
+                found = True
+        assert found, "datafog_error event not found"
+
+    def test_posthog_endpoint_url(self, mock_urlopen):
+        from datafog.telemetry import _send_event
+
+        _send_event("test_event", {"k": "v"})
+        time.sleep(0.3)
+
+        assert mock_urlopen.called
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://us.i.posthog.com/capture/"
+
+    def test_content_type_is_json(self, mock_urlopen):
+        from datafog.telemetry import _send_event
+
+        _send_event("test_event", {"k": "v"})
+        time.sleep(0.3)
+
+        assert mock_urlopen.called
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Content-type") == "application/json"
+
+
+# ===========================================================================
+# Group 5: Integration - detect/process/DataFog/TextService trigger events
+# ===========================================================================
+
+
+class TestIntegration:
+    def test_detect_triggers_telemetry(self, mock_urlopen):
+        from datafog import detect
+
+        detect("Contact john@example.com")
+        time.sleep(0.3)
+
+        events = []
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            events.append(body["event"])
+        assert "datafog_function_called" in events
+
+    def test_process_triggers_telemetry(self, mock_urlopen):
+        from datafog import process
+
+        process("Contact john@example.com", anonymize=True)
+        time.sleep(0.3)
+
+        events = []
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            events.append(body["event"])
+        assert "datafog_function_called" in events
+
+    def test_datafog_class_triggers_telemetry(self, mock_urlopen):
+        from datafog.main import DataFog
+
+        df = DataFog()
+        df.detect("john@example.com")
+        time.sleep(0.3)
+
+        events = []
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            events.append(body["event"])
+        assert "datafog_function_called" in events
+
+    def test_text_service_triggers_telemetry(self, mock_urlopen):
+        try:
+            from datafog.services.text_service import TextService
+        except ImportError:
+            pytest.skip("TextService requires optional dependencies (aiohttp)")
+
+        ts = TextService(engine="regex")
+        ts.annotate_text_sync("john@example.com")
+        time.sleep(0.3)
+
+        events = []
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            events.append(body["event"])
+        assert "datafog_function_called" in events
+
+    def test_core_detect_pii_triggers_telemetry(self, mock_urlopen):
+        try:
+            from datafog.core import detect_pii
+
+            detect_pii("john@example.com")
+        except ImportError:
+            pytest.skip("detect_pii requires TextService with optional dependencies")
+            return
+
+        time.sleep(0.3)
+
+        events = []
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            events.append(body["event"])
+        assert "datafog_function_called" in events
+
+
+# ===========================================================================
+# Group 6: Edge cases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    def test_empty_text(self, mock_urlopen):
+        from datafog.telemetry import _get_text_length_bucket, track_function_call
+
+        track_function_call(
+            "detect",
+            "datafog",
+            text_length_bucket=_get_text_length_bucket(0),
+        )
+        time.sleep(0.3)
+        # Should not raise
+
+    def test_large_text_bucket(self, mock_urlopen):
+        from datafog.telemetry import _get_text_length_bucket
+
+        assert _get_text_length_bucket(10_000_000) == "100k+"
+
+    def test_concurrent_init(self, mock_urlopen):
+        """Multiple threads calling _ensure_initialized should only init once."""
+        from datafog.telemetry import _ensure_initialized
+
+        threads = [threading.Thread(target=_ensure_initialized) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        time.sleep(0.5)
+        # Count init events
+        init_count = 0
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            if body["event"] == "datafog_init":
+                init_count += 1
+        assert init_count == 1
+
+    def test_file_write_failure_handled(self, tmp_path, monkeypatch):
+        """If we can't persist the ID, it still works."""
+        import datafog.telemetry as tel
+
+        tel._anonymous_id = None
+
+        # Point to a read-only path
+        def fake_home():
+            return tmp_path / "nonexistent" / "deep" / "path"
+
+        monkeypatch.setattr(Path, "home", fake_home)
+
+        # Should not raise, generates ID in memory
+        anon_id = tel._get_anonymous_id()
+        assert len(anon_id) == 64
+
+    def test_dedup_nested_calls(self, mock_urlopen):
+        """Nested track_function_call should only record the outer call."""
+        from datafog.telemetry import track_function_call
+
+        # Simulate: process() calls detect() internally
+        # The outer call sets _scope.active = True
+        track_function_call("process", "datafog", method="redact")
+        time.sleep(0.3)
+
+        func_events = []
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            if body["event"] == "datafog_function_called":
+                func_events.append(body["properties"]["function"])
+
+        # Only one function_called event should be present
+        assert len(func_events) == 1
+        assert func_events[0] == "process"
+
+    def test_detect_ci_returns_bool(self):
+        from datafog.telemetry import _detect_ci
+
+        result = _detect_ci()
+        assert isinstance(result, bool)
+
+    def test_detect_installed_extras_returns_list(self):
+        from datafog.telemetry import _detect_installed_extras
+
+        result = _detect_installed_extras()
+        assert isinstance(result, list)
+
+    def test_services_init_does_not_require_aiohttp(self):
+        """TextService should be importable without aiohttp/PIL (services/__init__.py fix)."""
+        from datafog.services.text_service import TextService
+
+        ts = TextService(engine="regex")
+        assert ts.engine == "regex"
+
+    def test_track_error_sent_on_exception(self, mock_urlopen):
+        """track_error should fire a datafog_error event."""
+        from datafog.telemetry import track_error
+
+        track_error("some_function", "ValueError", engine="regex")
+        time.sleep(0.3)
+
+        error_events = []
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            if body["event"] == "datafog_error":
+                error_events.append(body["properties"])
+
+        assert len(error_events) == 1
+        assert error_events[0]["function"] == "some_function"
+        assert error_events[0]["error_type"] == "ValueError"
+        assert error_events[0]["engine"] == "regex"
+
+    def test_pipeline_error_triggers_track_error(self, mock_urlopen):
+        """DataFog.run_text_pipeline_sync should fire datafog_error on failure."""
+        from datafog.main import DataFog
+
+        df = DataFog()
+        # Pass a non-list to trigger a TypeError inside the pipeline
+        try:
+            df.run_text_pipeline_sync(123)
+        except Exception:
+            pass
+
+        time.sleep(0.3)
+
+        error_events = []
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            body = json.loads(req.data.decode("utf-8"))
+            if body["event"] == "datafog_error":
+                error_events.append(body["properties"])
+
+        assert len(error_events) >= 1
+        assert error_events[0]["function"] == "DataFog.run_text_pipeline_sync"


### PR DESCRIPTION
## Summary

- **New `datafog/telemetry.py`**: Anonymous, opt-out usage telemetry via PostHog's `/capture/` API using only stdlib (`urllib.request`) — zero new dependencies
- **Instrumented all public API surfaces**: `detect()`, `process()`, `DataFog` class, `TextService`, core functions, and all 5 CLI commands
- **Wired `track_error()` into exception handlers** across `core.py`, `main.py`, and `client.py`
- **Fixed `services/__init__.py`**: Bare imports of heavy deps now wrapped in `try/except`
- **Fixed pre-existing bug**: `detect()` in `__init__.py` referenced `RegexAnnotator` without calling lazy import
- **Added README telemetry disclosure section**
- **44 new tests** covering opt-out, privacy, non-blocking behavior, payload correctness, integration, and edge cases

## Test plan

- [x] 44 telemetry tests pass
- [x] Existing tests pass with zero regressions
- [x] `DATAFOG_NO_TELEMETRY=1` disables all telemetry
- [x] Dependency audit confirms no disruption to conditional install pattern
- [ ] Verify events appear in PostHog dashboard
- [ ] Verify opt-out prevents events in PostHog