### PR TITLE
Add v4.4 bridge release runway

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report something that is broken or surprising.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for reporting a DataFog issue.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction
+      description: Minimal code, command, or steps to reproduce.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: DataFog version
+      placeholder: "4.3.0"
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.12.4"
+  - type: dropdown
+    id: profile
+    attributes:
+      label: Install profile
+      options:
+        - core
+        - cli
+        - nlp
+        - nlp-advanced
+        - ocr
+        - distributed
+        - all
+        - not sure
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: OS, package manager, relevant dependency versions, or CI link.
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, or related issues.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: https://github.com/DataFog/datafog-python/security/advisories/new
+    about: Please report security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest an improvement or new workflow.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem would this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like DataFog to do?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Core scan/redaction
+        - CLI
+        - LLM guardrails
+        - NLP engines
+        - OCR/image processing
+        - Spark/distributed processing
+        - Packaging/install
+        - Documentation
+        - Other
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Docs
+- [ ] Tests
+- [ ] Chore
+
+## Target Branch
+
+- [ ] This PR targets `dev`
+- [ ] This PR targets `main` for a release/hotfix
+
+## Validation
+
+Commands run:
+
+```bash
+
+```
+
+Optional profiles tested:
+
+- [ ] core
+- [ ] cli
+- [ ] nlp
+- [ ] nlp-advanced
+- [ ] ocr
+- [ ] distributed
+
+## Notes For Reviewers
+
+Mention API changes, migrations, warnings, or release-note needs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         install-profile: ["core", "nlp", "nlp-advanced"]
+        exclude:
+          # v4.4.0 claims Python 3.13 support for core + CLI first.
+          # Optional heavyweight profiles remain validated separately before
+          # we advertise Python 3.13 support for them.
+          - python-version: "3.13"
+            install-profile: "nlp"
+          - python-version: "3.13"
+            install-profile: "nlp-advanced"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,8 +139,40 @@ jobs:
           OMP_NUM_THREADS=4 MKL_NUM_THREADS=4 OPENBLAS_NUM_THREADS=4 python tests/simple_performance_test.py
 
   # ── 3. Build & Publish ────────────────────────────────────────────────
+  python313-core:
+    needs: determine-release
+    if: needs.determine-release.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.determine-release.outputs.target_branch }}
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install core + CLI dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov coverage
+          pip install -e ".[dev,cli]"
+
+      - name: Run Python 3.13 core + CLI tests
+        run: |
+          pytest tests/ \
+            -m "not slow" \
+            --ignore=tests/test_gliner_annotator.py \
+            --ignore=tests/test_image_service.py \
+            --ignore=tests/test_ocr_integration.py \
+            --ignore=tests/test_spark_integration.py \
+            --ignore=tests/test_text_service_integration.py
+
   publish:
-    needs: [determine-release, test]
+    needs: [determine-release, test, python313-core]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,99 @@
-# Contributing guidelines
+# Contributing to DataFog Python
 
-# Contributors
+Thanks for helping improve DataFog. The project welcomes issues, bug reports,
+documentation fixes, tests, and pull requests.
+
+Please follow the [Code of Conduct](CODE_OF_CONDUCT.md) in all project spaces.
+
+## Branch And PR Policy
+
+DataFog uses `dev` as the default development branch and `main` as the stable
+release branch.
+
+Use this workflow for normal contributions:
+
+1. Fork the repository or create a topic branch from `dev`.
+2. Name branches with a GitHub username prefix when practical, for example
+   `sidmohan0/dfpy-v44-bridge` or `yourname/fix-cli-redaction`.
+3. Open pull requests into `dev`.
+4. Keep pull requests focused and include tests or docs when behavior changes.
+
+Use `main` only for stable release promotion or urgent release hotfixes.
+Do not use `dev` or `main` as working branches.
+
+Maintainers should prefer pull requests even for small changes. Protected branch
+rules should prevent branch deletion, require CI before merge, and avoid direct
+pushes except for explicit emergency maintenance.
+
+## Local Development
+
+```bash
+git clone https://github.com/datafog/datafog-python
+cd datafog-python
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+python -m pip install --upgrade pip
+pip install -e ".[dev,cli]"
+```
+
+For optional NLP or OCR work, install the relevant extras:
+
+```bash
+pip install -e ".[dev,cli,nlp]"
+pip install -e ".[dev,cli,nlp,nlp-advanced]"
+pip install -e ".[all,dev]"
+```
+
+## Tests
+
+Run the core test suite before opening a pull request:
+
+```bash
+pytest tests/ -m "not slow" \
+  --ignore=tests/test_gliner_annotator.py \
+  --ignore=tests/test_image_service.py \
+  --ignore=tests/test_ocr_integration.py \
+  --ignore=tests/test_spark_integration.py \
+  --ignore=tests/test_text_service_integration.py
+```
+
+Run the focused test file for the area you changed whenever possible. For
+documentation-only changes, build the docs:
+
+```bash
+sphinx-build -b html docs docs/_build/html
+```
+
+## Pull Request Checklist
+
+Before requesting review:
+
+- Rebase or merge the latest `dev`.
+- Add or update tests for behavior changes.
+- Update docs for user-facing changes.
+- Keep public API changes explicit in the PR description.
+- Note any optional dependency profile you tested, such as `core`, `nlp`, or
+  `nlp-advanced`.
+
+## Commit Messages
+
+Use clear, descriptive commit messages. Conventional-style prefixes are welcome
+but not required, for example:
+
+- `fix: handle empty scan input`
+- `docs: clarify branch policy`
+- `test: cover v5 preview redaction wrapper`
+
+## Legal
+
+By submitting a pull request, you license your contribution under the project
+[license](LICENSE). You also affirm that you authored the contribution or have
+the right to submit it under the project license.
+
+## Contributors
+
+Thanks to early contributors including:
 
 - sroy9675
 - pselvana
 - sidmohan0
-
-for their help
-
-The datafog community appreciates your contributions via issues and
-pull requests. Note that the [code of conduct](CODE_OF_CONDUCT.md)
-applies to all interactions with the datafog project, including
-issues and pull requests.
-
-When submitting pull requests, please follow the style guidelines of
-the project, ensure that your code is tested and documented, and write
-good commit messages, e.g., following [these
-guidelines](https://chris.beams.io/posts/git-commit/).
-
-By submitting a pull request, you are licensing your code under the
-project [license](LICENSE) and affirming that you either own copyright
-(automatic for most individuals) or are authorized to distribute under
-the project license (e.g., in case your employer retains copyright on
-your work).
-
-### Legal Notice
-
-When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+Please do not report security vulnerabilities in public issues.
+
+Use GitHub private vulnerability reporting when available:
+
+https://github.com/DataFog/datafog-python/security/advisories/new
+
+If private vulnerability reporting is unavailable, contact the maintainers
+directly and include:
+
+- affected versions;
+- a minimal reproduction or proof of concept;
+- expected impact;
+- any known mitigations.
+
+We will acknowledge valid reports as quickly as practical and coordinate fixes
+before public disclosure.

--- a/datafog/__init__.py
+++ b/datafog/__init__.py
@@ -8,8 +8,18 @@ Optional extras available for advanced features:
 - pip install datafog[all] - for all features
 """
 
+import warnings
+
 from .__about__ import __version__
 from .agent import create_guardrail, filter_output, sanitize, scan_prompt
+from .engine import (
+    Entity,
+    RedactResult,
+    ScanResult,
+    redact as _redact_entities,
+    scan as _scan,
+    scan_and_redact as _scan_and_redact,
+)
 
 # Core API functions - always available (lightweight)
 from .core import anonymize_text, detect_pii, get_supported_entities, scan_text
@@ -134,6 +144,88 @@ SparkService = _optional_import(
 )
 
 
+_REDACT_PRESETS = {
+    "default": "token",
+    "llm": "token",
+    "mask": "mask",
+    "hash": "hash",
+    "replace": "pseudonymize",
+    "pseudonymize": "pseudonymize",
+}
+
+
+def _warn_v5_replacement(old_api: str, replacement: str) -> None:
+    warnings.warn(
+        f"datafog.{old_api}() is deprecated for v5. Use {replacement} instead. "
+        "This compatibility shim will remain through the v5.x line.",
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
+def scan(
+    text: str,
+    engine: str = "regex",
+    entity_types: list[str] | None = None,
+) -> ScanResult:
+    """
+    v5-preview scan entrypoint.
+
+    Defaults to the lightweight regex engine so the core install works without
+    optional dependency fallback warnings.
+    """
+    return _scan(text=text, engine=engine, entity_types=entity_types)
+
+
+def redact(
+    text: str,
+    entities: list[Entity] | None = None,
+    engine: str = "regex",
+    entity_types: list[str] | None = None,
+    strategy: str = "token",
+    preset: str | None = None,
+) -> RedactResult:
+    """
+    v5-preview redaction entrypoint.
+
+    If entities are provided, redact those spans. Otherwise, scan text first
+    using the selected engine and redact the detected entities.
+    """
+    if preset is not None:
+        try:
+            strategy = _REDACT_PRESETS[preset]
+        except KeyError as exc:
+            allowed = ", ".join(sorted(_REDACT_PRESETS))
+            raise ValueError(f"preset must be one of: {allowed}") from exc
+
+    if entities is not None:
+        return _redact_entities(text=text, entities=entities, strategy=strategy)
+
+    return _scan_and_redact(
+        text=text,
+        engine=engine,
+        entity_types=entity_types,
+        strategy=strategy,
+    )
+
+
+def protect(
+    entity_types: list[str] | None = None,
+    engine: str = "regex",
+    strategy: str = "token",
+    on_detect: str = "redact",
+):
+    """
+    v5-preview guardrail factory.
+    """
+    return create_guardrail(
+        entity_types=entity_types,
+        engine=engine,
+        strategy=strategy,
+        on_detect=on_detect,
+    )
+
+
 # Simple API for core functionality (backward compatibility)
 def detect(text: str) -> list:
     """
@@ -150,6 +242,12 @@ def detect(text: str) -> list:
         >>> detect("Contact john@example.com")
         [{'type': 'EMAIL', 'value': 'john@example.com', 'start': 8, 'end': 24}]
     """
+    _warn_v5_replacement("detect", "datafog.scan()")
+
+    return _detect_impl(text)
+
+
+def _detect_impl(text: str) -> list:
     import time as _time
 
     _start = _time.monotonic()
@@ -217,11 +315,13 @@ def process(text: str, anonymize: bool = False, method: str = "redact") -> dict:
             'findings': [{'type': 'EMAIL', 'value': 'john@example.com', ...}]
         }
     """
+    _warn_v5_replacement("process", "datafog.scan() or datafog.redact()")
+
     import time as _time
 
     _start = _time.monotonic()
 
-    findings = detect(text)
+    findings = _detect_impl(text)
 
     result = {"original": text, "findings": findings}
 
@@ -268,6 +368,12 @@ def process(text: str, anonymize: bool = False, method: str = "redact") -> dict:
 # Core exports
 __all__ = [
     "__version__",
+    "Entity",
+    "ScanResult",
+    "RedactResult",
+    "scan",
+    "redact",
+    "protect",
     "detect",
     "process",
     "detect_pii",

--- a/datafog/__init__.py
+++ b/datafog/__init__.py
@@ -12,17 +12,13 @@ import warnings
 
 from .__about__ import __version__
 from .agent import create_guardrail, filter_output, sanitize, scan_prompt
-from .engine import (
-    Entity,
-    RedactResult,
-    ScanResult,
-    redact as _redact_entities,
-    scan as _scan,
-    scan_and_redact as _scan_and_redact,
-)
 
 # Core API functions - always available (lightweight)
 from .core import anonymize_text, detect_pii, get_supported_entities, scan_text
+from .engine import Entity, RedactResult, ScanResult
+from .engine import redact as _redact_entities
+from .engine import scan as _scan
+from .engine import scan_and_redact as _scan_and_redact
 
 # Essential models - always available
 from .models.common import EntityTypes

--- a/datafog/config.py
+++ b/datafog/config.py
@@ -9,7 +9,7 @@ import os
 from enum import Enum
 from typing import Optional
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class DataFogConfig(BaseSettings):
@@ -24,6 +24,8 @@ class DataFogConfig(BaseSettings):
     All settings have default values that can be overridden as needed. The class
     uses Pydantic for data validation and settings management.
     """
+
+    model_config = SettingsConfigDict(env_prefix="DATAFOG_", case_sensitive=False)
 
     # API Keys and Authentication
     api_key: str = os.environ.get("DATAFOG_API_KEY", "")
@@ -47,10 +49,6 @@ class DataFogConfig(BaseSettings):
 
     # Logging
     log_level: str = "INFO"
-
-    class Config:
-        env_prefix = "DATAFOG_"
-        case_sensitive = False
 
     def update(self, **kwargs):
         """Update configuration with new values"""

--- a/datafog/models/anonymizer.py
+++ b/datafog/models/anonymizer.py
@@ -7,7 +7,7 @@ import secrets
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from .annotator import AnnotationResult
 from .common import EntityTypes
@@ -34,13 +34,12 @@ class AnonymizerRequest(BaseModel):
 
 
 class AnonymizationResult(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     anonymized_text: str
     anonymized_entities: List[dict] = Field(
         default_factory=list, alias="replaced_entities"
     )
-
-    class Config:
-        populate_by_name = True
 
 
 class Anonymizer(BaseModel):

--- a/datafog/processing/text_processing/spacy_pii_annotator.py
+++ b/datafog/processing/text_processing/spacy_pii_annotator.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 PII_ANNOTATION_LABELS = [
     "CARDINAL",
@@ -27,6 +27,8 @@ MAXIMAL_STRING_SIZE = 1000000
 
 
 class SpacyPIIAnnotator(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     nlp: Any
 
     @classmethod
@@ -75,6 +77,3 @@ class SpacyPIIAnnotator(BaseModel):
             return {
                 label: [] for label in PII_ANNOTATION_LABELS
             }  # Return empty annotations in case of error
-
-    class Config:
-        arbitrary_types_allowed = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,3 +30,7 @@ autosummary_generate = True
 napoleon_use_rtype = False
 napoleon_use_ivar = False
 napoleon_use_param = False
+
+# Keep API docs buildable from the lightweight core/dev install. These
+# integrations are documented, but they live behind optional extras.
+autodoc_mock_imports = ["PIL", "pytesseract", "spacy"]

--- a/docs/important-concepts.rst
+++ b/docs/important-concepts.rst
@@ -1,6 +1,6 @@
-===========
+==================
 Important Concepts
-===========
+==================
 
 Overview
 --------
@@ -20,6 +20,7 @@ Key data models to support PII annotation and OCR analysis.
 Processors
 ^^^^^^^^^^^
 Main processors:
+
 * SpacyAnnotator
     Text annotation with spaCy
 * DonutProcessor
@@ -30,6 +31,7 @@ Main processors:
 Services
 ^^^^^^^^^^^
 Core services:
+
 * ImageService
     Image handling and OCR
 * SparkService
@@ -47,6 +49,7 @@ Data Models
 .. autosummary::
    :toctree: generated/
    :template: class.rst
+
    AnnotatorRequest
    AnnotationResult
    AnalysisExplanation
@@ -57,6 +60,7 @@ Data Models
 .. autosummary::
    :toctree: generated/
    :template: class.rst
+
    EntityTypes
    Pattern
    PatternRecognizer
@@ -68,6 +72,7 @@ Data Models
 .. autosummary::
    :toctree: generated/
    :template: class.rst
+
    SpacyAnnotator
 
 Processors
@@ -98,6 +103,7 @@ Services
 .. autosummary::
    :toctree: generated/
    :template: class.rst
+
    ImageDownloader
    ImageService
 
@@ -107,6 +113,7 @@ Services
 .. autosummary::
    :toctree: generated/
    :template: class.rst
+
    SparkService
 
 
@@ -116,4 +123,5 @@ Services
 .. autosummary::
    :toctree: generated/
    :template: class.rst
+
    TextService

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,13 +12,17 @@ DataFog is an open-source tool for PII detection and anonymization of unstructur
    python-sdk
    definitions
    roadmap
+   v44-bridge-release
+   v5-product-brief
+   v5-compatibility-matrix
+   v5-cut-line
 
 =====================
 Getting Started
 =====================
 
----------------------
 Installation
+------------
 
 Install DataFog via pip:
 
@@ -102,5 +106,3 @@ Scan image for PII:
    asyncio.run(run_ocr_pipeline_demo())
 
 For detailed information on the Python SDK, see :doc:`python-sdk`.
-
-

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -9,6 +9,69 @@ to a lightweight, modular architecture with optional extras.
    :local:
    :depth: 1
 
+v4.4.0 - Python 3.13 and v5 Migration Bridge
+--------------------------------------------
+
+Before v5.0.0, DataFog should ship a focused v4.4.0 bridge release. The
+purpose is to give users a concrete compatibility win while introducing the
+v5 direction gently.
+
+v4.4.0 should focus on:
+
+* Python 3.13 support for the core SDK and CLI.
+* Dependency validation for optional profiles without blocking core/CLI.
+* v5-style preview APIs where they can land safely.
+* Targeted deprecation warnings with no warnings on import.
+* Migration docs and release notes that announce the v5 path.
+
+Scope artifact:
+
+* :doc:`v44-bridge-release`
+
+v5.0.0 - Offline PII Firewall for AI Apps
+-----------------------------------------
+
+The v5.0.0 release is scoped around a sharper adoption wedge:
+
+   DataFog should be the fastest, easiest offline PII firewall for AI apps,
+   logs, and datasets.
+
+The release should prioritize trust and time-to-first-value over broad
+enterprise surface area. The first path should be a core install, a simple
+top-level API, no network surprises, and copy-pasteable workflows for LLM
+prompts/outputs, logs, JSONL datasets, and CI checks.
+
+Scope artifacts:
+
+* :doc:`v5-product-brief`
+* :doc:`v5-compatibility-matrix`
+* :doc:`v5-cut-line`
+
+v5.0.0 must focus on:
+
+* Stable top-level APIs: ``scan``, ``redact``, ``protect``, and ``restore``.
+* Privacy-safe defaults: no default network behavior, no runtime package
+  installation, and no implicit model downloads.
+* Policy-based redaction with presets for LLMs, logs, strict workflows, and
+  datasets.
+* Reversible token sessions that are explicit and opt-in.
+* LLM guardrails, including sync, async, and streaming protection.
+* CLI workflows for stdin, files, directories, CSV, JSONL, machine-readable
+  output, and CI-friendly exit codes.
+* Custom recognizers and stronger structured detection for app/log/secrets
+  data.
+* Modern packaging and release gates for install profiles, no-network
+  behavior, import time, wheel size, accuracy, coverage, and benchmarks.
+
+Deferred to v5.1+:
+
+* OCR overhaul.
+* Spark overhaul.
+* Cloud DLP integrations.
+* Enterprise dashboards and analytics.
+* Broad multilingual model tuning.
+* Large Presidio-style framework expansion.
+
 ✅ 4.1.0 (Released)
 --------------------
 The ``4.1.0`` release represents a major architectural shift to a lightweight

--- a/docs/v44-bridge-release.rst
+++ b/docs/v44-bridge-release.rst
@@ -1,0 +1,145 @@
+=================================
+v4.4 Bridge Release Scope
+=================================
+
+Status
+------
+
+Scope and implementation notes for the v4.4.0 transition release.
+
+Linear project: `DataFog Python v4.4.0: Python 3.13 + v5 Migration Bridge <https://linear.app/threadfork/project/datafog-python-v440-python-313-v5-migration-bridge-0afcd4211a58>`_
+
+Release Thesis
+--------------
+
+v4.4.0 should be a bridge release before v5. It should give users an
+immediate compatibility win with Python 3.13 and introduce the v5 migration
+path without forcing a disruptive API change.
+
+The release should feel positive:
+
+* Python 3.13 support for the core SDK and CLI.
+* A preview of the v5-style API path.
+* Targeted, actionable deprecation warnings.
+* Migration docs that explain what is changing and why.
+
+Required Scope
+--------------
+
+Python 3.13 Core and CLI Support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+v4.4.0 should support Python 3.13 for the lightweight core package and CLI
+workflow.
+
+Required changes:
+
+* Package metadata allows Python 3.13.
+* Package classifiers include Python 3.13.
+* CI runs the core/CLI profile on Python 3.13.
+* Release notes clearly state that Python 3.13 support is guaranteed for
+  core and CLI.
+
+Optional Dependency Stance
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Optional heavy profiles should be validated where practical, but they should
+not block v4.4.0 unless they break the core or CLI install.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Profile
+     - v4.4.0 support stance
+     - Notes
+   * - ``core``
+     - Required on Python 3.13
+     - Must install and run scan/redaction tests.
+   * - ``cli``
+     - Required on Python 3.13
+     - Must install and run CLI smoke tests.
+   * - ``nlp``
+     - Validate where practical
+     - spaCy advertises Python 3.13 support in current releases, but model
+       install behavior should be tested before claiming full support.
+   * - ``nlp-advanced``
+     - Provisional
+     - GLiNER and PyTorch dependency behavior should be tested separately.
+   * - ``ocr``
+     - Provisional
+     - OCR is not on the v4.4 or v5.0 critical path.
+   * - ``distributed``
+     - Provisional
+     - Spark support should not block the bridge release.
+
+v5 Preview APIs
+~~~~~~~~~~~~~~~
+
+v4.4.0 should make the recommended v5 path available early where it can be
+done without large internal churn.
+
+Preview path:
+
+* ``datafog.scan``
+* ``datafog.redact``
+* ``datafog.protect`` if it can be exposed through existing guardrail helpers
+  without pulling in the full v5 policy engine.
+
+The preview APIs should delegate through current stable internals and should
+not require optional heavy dependencies.
+
+For the bridge release, preview APIs should default to the lightweight regex
+engine so a core-only install does not emit optional dependency fallback
+warnings. Users can still opt into ``engine="smart"`` explicitly.
+
+Deprecation Warning Policy
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+v4.4.0 should introduce migration signals, not warning noise.
+
+Rules:
+
+* No warnings on ``import datafog``.
+* Warnings only fire when selected legacy convenience APIs are called.
+* Warning messages name the v5-style replacement.
+* Warnings use ``stacklevel`` so they point to user code where practical.
+* ``DataFog`` and ``TextService`` should not warn by default in v4.4.0.
+
+Candidate warning targets:
+
+* ``datafog.detect`` -> ``datafog.scan``
+* ``datafog.process`` -> ``datafog.redact``
+
+Deferred warning targets:
+
+* ``detect_pii`` -> ``scan``
+* ``anonymize_text`` -> ``redact``
+* ``scan_text`` -> ``scan``
+* Old CLI commands once v5-style CLI aliases exist.
+
+Non-Goals
+---------
+
+v4.4.0 should not attempt to complete v5.
+
+Out of scope:
+
+* Full v5 policy engine.
+* Reversible token sessions.
+* Streaming guardrails.
+* OCR overhaul.
+* Spark overhaul.
+* Modern packaging migration to ``pyproject.toml``.
+* Broad dependency cleanup beyond what Python 3.13 requires.
+
+Success Criteria
+----------------
+
+v4.4.0 is ready when:
+
+* Python 3.13 core/CLI CI is green.
+* Package metadata advertises Python 3.13 support.
+* v5-style API docs are visible.
+* Deprecation warnings are targeted and tested.
+* Release notes frame the release as a compatibility win and migration runway.

--- a/docs/v5-compatibility-matrix.rst
+++ b/docs/v5-compatibility-matrix.rst
@@ -1,0 +1,158 @@
+=======================
+v5 Compatibility Matrix
+=======================
+
+Status
+------
+
+Scope lock draft for the v4 to v5 migration contract.
+
+Migration Stance
+----------------
+
+v5 should be adoption-first without being hostile to existing users.
+The default posture is:
+
+* Make the new API obvious and stable.
+* Keep existing public APIs working through compatibility shims where
+  practical.
+* Warn only when a user is on a path that should move to the v5 API.
+* Break behavior only when required for trust, privacy, or install
+  predictability.
+
+Compatibility Matrix
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 24 20 30
+
+   * - Surface
+     - v4 State
+     - v5 Status
+     - v5 Direction
+   * - ``datafog.scan``
+     - v4.4 bridge preview top-level API.
+     - Stable public API.
+     - Keep as the obvious scan entrypoint returning typed scan results.
+   * - ``datafog.redact``
+     - v4.4 bridge preview top-level API.
+     - Stable public API.
+     - Expand user-facing presets and policy support while preserving typed
+       redaction metadata.
+   * - ``datafog.protect``
+     - v4.4 bridge preview alias around ``create_guardrail``.
+     - Stable public API.
+     - Add decorator/context API for sync, async, and streaming workflows.
+   * - ``datafog.restore``
+     - No primary public API.
+     - Stable public API.
+     - Restore text from explicit reversible token sessions only.
+   * - ``datafog.sanitize``
+     - Top-level LLM helper.
+     - Supported shim.
+     - Keep as alias-like convenience around ``redact``.
+   * - ``datafog.scan_prompt``
+     - Top-level LLM helper.
+     - Supported shim.
+     - Keep for compatibility; docs should prefer ``scan`` or ``protect``.
+   * - ``datafog.filter_output``
+     - Top-level LLM helper.
+     - Supported shim.
+     - Keep for compatibility; docs should prefer ``redact`` or ``protect``.
+   * - ``datafog.create_guardrail``
+     - Top-level guardrail factory.
+     - Supported shim.
+     - Keep, but docs should make ``protect`` the first path.
+   * - ``datafog.detect``
+     - Top-level convenience detection API.
+     - Deprecated shim.
+     - Delegate to ``scan`` and warn with replacement guidance.
+   * - ``datafog.process``
+     - Top-level detect/process helper.
+     - Deprecated shim.
+     - Delegate to ``scan`` / ``redact`` and warn with replacement guidance.
+   * - ``detect_pii``
+     - Core helper returning dicts.
+     - Deprecated shim.
+     - Keep temporarily for v4 users; prefer ``scan`` typed results.
+   * - ``anonymize_text``
+     - Core anonymization helper.
+     - Deprecated shim.
+     - Keep temporarily; prefer ``redact`` with a policy or preset.
+   * - ``scan_text``
+     - Boolean or dict helper.
+     - Deprecated shim.
+     - Keep temporarily; prefer ``scan``.
+   * - ``get_supported_entities``
+     - Returns core regex entity names.
+     - Supported utility.
+     - Keep, but align with recognizer registry and locale packs.
+   * - ``DataFog``
+     - Legacy class-based entrypoint.
+     - Compatibility shim.
+     - Keep through v5 with warnings for new construction patterns.
+   * - ``TextService``
+     - Service class with engine selection and legacy return shapes.
+     - Compatibility shim.
+     - Keep for existing users; new docs should use top-level API.
+   * - ``TextPIIAnnotator``
+     - Lightweight wrapper.
+     - Deprecated shim.
+     - Keep only if needed for compatibility; prefer ``scan``.
+   * - ``RegexAnnotator``
+     - Exposed implementation detail.
+     - Advanced API.
+     - Keep available for advanced users, but docs should prefer registry.
+   * - ``datafog.engine``
+     - Internal boundary introduced before v5.
+     - Internal implementation.
+     - Keep stable enough for wrappers, but public imports should use top-level
+       APIs or public model paths.
+   * - CLI ``scan-text``, ``redact-text``, ``replace-text``, ``hash-text``
+     - Current command set.
+     - Deprecated command shims.
+     - Add v5 ``scan``, ``redact``, and ``audit`` commands; keep old commands
+       with warnings.
+   * - CLI ``scan-image``
+     - OCR-oriented command.
+     - Optional legacy command.
+     - Keep under OCR extra; do not make it a v5.0 adoption path.
+   * - OCR services and processors
+     - Optional extras with heavyweight dependencies.
+     - Deferred for v5.1+ overhaul.
+     - Keep install hints clear; no runtime package installs.
+   * - Spark services and UDFs
+     - Optional distributed path.
+     - Deferred for v5.1+ overhaul.
+     - Keep compatibility where practical; no runtime package installs.
+   * - Telemetry
+     - Default-on opt-out telemetry.
+     - Trust-critical behavior change.
+     - Make opt-in or no-network-by-default.
+   * - ``*_lean`` and ``*_original`` modules
+     - Parallel historical implementations.
+     - Remove or make private after migration path.
+     - Consolidate around the v5 core and delete duplicate runtime surfaces.
+
+Warning Policy
+--------------
+
+Deprecation warnings should be specific and actionable. They should name the
+old API, the v5 replacement, and the planned support window. For example:
+
+.. code-block:: text
+
+   datafog.detect() is deprecated in v5. Use datafog.scan() instead.
+   This compatibility shim will be supported through the v5.x line.
+
+Breaking-Change Criteria
+------------------------
+
+A v5 breaking change is acceptable only when it materially improves one of:
+
+* Privacy or trust defaults.
+* Core install reliability.
+* No-network behavior.
+* Public API clarity.
+* Correctness of redaction metadata.

--- a/docs/v5-cut-line.rst
+++ b/docs/v5-cut-line.rst
@@ -1,0 +1,142 @@
+=================
+v5.0 Release Line
+=================
+
+Status
+------
+
+Scope lock draft for what belongs in v5.0.0 versus v5.1+.
+
+v5.0 Release Promise
+--------------------
+
+v5.0.0 should ship a sharp, adoption-focused SDK:
+
+   The fastest, easiest offline PII firewall for AI apps, logs, and
+   datasets.
+
+The release is not judged by how much surface area it adds. It is judged by
+whether a new user can trust it quickly, understand it quickly, and protect
+real application data quickly.
+
+Must Ship in v5.0
+-----------------
+
+Core API
+~~~~~~~~
+
+* Stable top-level ``scan``, ``redact``, ``protect``, and ``restore`` APIs.
+* Public typed result objects and entity models.
+* Compatibility shims for important v4 APIs.
+* API snapshot tests and executable quickstart smoke tests.
+
+Trust Defaults
+~~~~~~~~~~~~~~
+
+* Telemetry opt-in or no-network-by-default.
+* No runtime package installation.
+* No implicit model downloads.
+* Safe redaction metadata by default.
+* No-network import and core API tests.
+
+Policy and Redaction
+~~~~~~~~~~~~~~~~~~~~
+
+* ``RedactionPolicy`` with entity filters, thresholds, locale, mapping
+  behavior, and actions per entity type.
+* Built-in presets for ``llm``, ``logs``, ``strict``, and ``dataset``.
+* Reversible ``TokenSession`` only when explicitly requested.
+* HMAC hashing and format-preserving masking strategies.
+
+LLM and App Workflows
+~~~~~~~~~~~~~~~~~~~~~
+
+* ``protect`` decorator for sync and async functions.
+* Streaming output filtering.
+* Guardrail session counters and safe audit metadata.
+* Examples for LLM calls, FastAPI middleware, logging filters, LangChain-style
+  adapters, and LlamaIndex-style adapters.
+
+CLI and Dataset Workflows
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* v5 CLI commands: ``scan``, ``redact``, and ``audit``.
+* Support for direct text, stdin, files, directories, CSV, and JSONL.
+* Machine-readable ``--json`` and ``--jsonl`` output.
+* CI-friendly ``--fail-on-detect`` behavior and exit codes.
+* Dataset audit summaries that avoid raw PII by default.
+
+Detection Quality
+~~~~~~~~~~~~~~~~~
+
+* Custom recognizer registry with regex and validator hooks.
+* Common app/log recognizers for secrets, tokens, API keys, IPv6, IBAN,
+  crypto wallets, and account identifiers.
+* ``us`` and ``global`` locale packs.
+* Deterministic overlap resolution and confidence scoring.
+* Expanded corpus and enforced accuracy thresholds in CI.
+
+Packaging and Release
+~~~~~~~~~~~~~~~~~~~~~
+
+* ``pyproject.toml`` as primary packaging metadata.
+* ``py.typed`` marker.
+* Clean runtime dependencies and optional extras.
+* CI gates for install profiles, import time, wheel size, no-network behavior,
+  coverage, accuracy, and benchmark regressions.
+* v4 to v5 migration guide and launch assets.
+
+Defer to v5.1+
+--------------
+
+OCR Overhaul
+~~~~~~~~~~~~
+
+OCR is useful, but it is not the adoption wedge for v5.0. Keep current OCR
+compatibility where practical and move OCR quality, preprocessing, and
+processor architecture to v5.1+.
+
+Spark and Distributed Processing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Spark support should not block the first v5 release. Keep install errors and
+compatibility sane, then revisit distributed workflows after the core API and
+CLI are stable.
+
+Cloud Integrations
+~~~~~~~~~~~~~~~~~~
+
+AWS, GCP, Azure, hosted APIs, and cloud DLP bridges are deferred. v5.0 should
+win first as an offline local SDK.
+
+Enterprise Analytics
+~~~~~~~~~~~~~~~~~~~~
+
+Dashboards, organization-wide reporting, and advanced analytics are deferred.
+The v5.0 audit surface should remain CLI/API friendly and privacy-safe.
+
+Broad Multilingual Expansion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+v5.0 may introduce locale structure, but broad multilingual tuning should wait
+until the v5 core is stable and measured.
+
+Large Presidio-Style Framework Expansion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+DataFog should not try to clone Presidio in v5.0. Custom recognizers are in
+scope, but a large enterprise recognizer framework is not.
+
+Scope Creep Test
+----------------
+
+A proposed v5.0 item should pass at least one of these tests:
+
+* Does it make first use faster or clearer?
+* Does it improve trust for a PII SDK?
+* Does it protect LLM, log, CLI, or dataset workflows?
+* Does it make the core install smaller, safer, or more predictable?
+* Does it reduce migration risk for existing users?
+
+If the answer is no, the item probably belongs in v5.1+.
+

--- a/docs/v5-product-brief.rst
+++ b/docs/v5-product-brief.rst
@@ -1,0 +1,114 @@
+================
+v5 Product Brief
+================
+
+Status
+------
+
+Scope lock draft for DataFog Python v5.0.0.
+
+Linear project: `DataFog Python v5.0.0: Offline PII Firewall for AI Apps <https://linear.app/threadfork/project/datafog-python-v500-offline-pii-firewall-for-ai-apps-78a1550a22f4>`_
+
+Product Thesis
+--------------
+
+DataFog v5 should be the fastest, easiest offline PII firewall for AI
+apps, logs, and datasets.
+
+The release should optimize for adoption over breadth. The first user
+experience should be a small install, a clear one-liner, and strong
+privacy defaults:
+
+.. code-block:: python
+
+   import datafog
+
+   result = datafog.redact("Email john@example.com", preset="llm")
+   safe_text = result.redacted_text
+
+In the v4.4 bridge release, ``scan``, ``redact``, and ``protect`` should default
+to the lightweight regex engine so the core install remains quiet. Higher-recall
+NLP paths can stay explicit through ``engine="smart"`` or optional extras.
+
+Primary Users
+-------------
+
+v5 is built first for developers who need to keep PII out of:
+
+* LLM prompts and model outputs.
+* Agent tool calls and MCP-style tool results.
+* Application logs, traces, analytics events, and support dumps.
+* JSONL, CSV, and text datasets used for evals or fine-tuning.
+* CI checks that should fail when accidental PII is present.
+
+Adoption Principles
+-------------------
+
+* **Time to first value under 60 seconds.** A new user should be able to
+  install DataFog and redact text without reading architecture docs.
+* **No network surprises.** A core install should not send telemetry,
+  download models, install packages, or open network connections by
+  default.
+* **One obvious API path.** The primary path is ``scan``, ``redact``,
+  ``protect``, and ``restore``.
+* **Safe metadata by default.** Redaction results should not expose
+  original PII mappings unless the user explicitly asks for a reversible
+  session.
+* **Workflow-first docs.** The first examples should be LLM protection,
+  logging filters, FastAPI middleware, CLI JSONL redaction, and custom
+  recognizers.
+* **Honest positioning.** DataFog should not try to out-Presidio
+  Presidio. It should win on lightweight offline protection for AI apps,
+  logs, and datasets.
+
+v5.0 Must-Haves
+---------------
+
+* Stable top-level APIs: ``datafog.scan``, ``datafog.redact``,
+  ``datafog.protect``, and ``datafog.restore``.
+* Public typed result objects for scans, entities, redaction results,
+  and reversible sessions.
+* Privacy-safe defaults: telemetry opt-in or no-network-by-default,
+  no runtime package installation, no implicit model downloads.
+* Policy-based redaction with presets for ``llm``, ``logs``,
+  ``strict``, and ``dataset``.
+* Reversible token sessions for workflows that need explicit
+  restore support.
+* LLM guardrails for sync, async, and streaming responses.
+* CLI support for stdin, files, directories, CSV, JSONL, machine-readable
+  output, and CI-friendly exit codes.
+* Custom recognizer registry for domain-specific PII and secrets.
+* Expanded corpus tests for app, log, and secret-like data.
+* Modern packaging, typed package marker, install-profile tests, and
+  release gates for accuracy, coverage, import time, wheel size, and
+  no-network behavior.
+
+Non-Goals for v5.0
+------------------
+
+The following work is intentionally outside the v5.0 critical path:
+
+* OCR overhaul.
+* Spark overhaul.
+* Cloud DLP integrations.
+* Enterprise dashboards or analytics products.
+* Broad multilingual model tuning.
+* A large Presidio-style recognizer framework.
+* Hosted service features.
+
+Success Metrics
+---------------
+
+* A clean core install can redact text in under 60 seconds from a fresh
+  environment.
+* ``pip install datafog`` stays lightweight and does not require spaCy,
+  PyTorch, OCR, Spark, or model downloads.
+* ``import datafog`` and core ``scan`` / ``redact`` calls make no network
+  requests by default.
+* The README quickstart uses the v5 API first and does not require legacy
+  classes.
+* At least five adoption workflows are documented and copy-pasteable:
+  LLM prompts/outputs, streaming outputs, logging, FastAPI, and JSONL CLI.
+* Accuracy and regression checks run in CI and produce readable artifacts.
+* Existing v4 users have a clear migration path with compatibility shims
+  and warnings instead of surprising breakage.

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=core_deps,
     extras_require=extras_require,
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10,<3.14",
     entry_points={
         "console_scripts": [
             "datafog=datafog.client:app [cli]",  # Requires cli extra
@@ -109,6 +109,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Text Processing",
         "Topic :: Security",

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -356,7 +356,8 @@ class TestIntegration:
     def test_detect_triggers_telemetry(self, mock_urlopen):
         from datafog import detect
 
-        detect("Contact john@example.com")
+        with pytest.warns(FutureWarning, match=r"Use datafog\.scan\(\) instead"):
+            detect("Contact john@example.com")
         time.sleep(0.3)
 
         events = []
@@ -369,7 +370,11 @@ class TestIntegration:
     def test_process_triggers_telemetry(self, mock_urlopen):
         from datafog import process
 
-        process("Contact john@example.com", anonymize=True)
+        with pytest.warns(
+            FutureWarning,
+            match=r"datafog\.scan\(\) or datafog\.redact\(\)",
+        ):
+            process("Contact john@example.com", anonymize=True)
         time.sleep(0.3)
 
         events = []

--- a/tests/test_v44_bridge_api.py
+++ b/tests/test_v44_bridge_api.py
@@ -78,7 +78,5 @@ def test_import_does_not_emit_migration_warnings() -> None:
         importlib.reload(datafog)
 
     assert not [
-        warning
-        for warning in captured
-        if issubclass(warning.category, FutureWarning)
+        warning for warning in captured if issubclass(warning.category, FutureWarning)
     ]

--- a/tests/test_v44_bridge_api.py
+++ b/tests/test_v44_bridge_api.py
@@ -1,0 +1,84 @@
+"""Tests for v4.4 bridge APIs that preview the v5 surface."""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+import datafog
+
+
+def test_top_level_scan_is_available_without_optional_extras() -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        result = datafog.scan("Email jane@example.com")
+
+    assert result.engine_used == "regex"
+    assert any(entity.type == "EMAIL" for entity in result.entities)
+    assert not captured
+
+
+def test_top_level_redact_scans_by_default() -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        result = datafog.redact("Email jane@example.com")
+
+    assert result.redacted_text != "Email jane@example.com"
+    assert "[EMAIL_1]" in result.redacted_text
+    assert result.mapping
+    assert not captured
+
+
+def test_top_level_redact_accepts_precomputed_entities() -> None:
+    text = "Email jane@example.com"
+    scan_result = datafog.scan(text, engine="regex")
+
+    result = datafog.redact(text, entities=scan_result.entities, strategy="mask")
+
+    assert "jane@example.com" not in result.redacted_text
+    assert "*" in result.redacted_text
+
+
+def test_top_level_redact_supports_preview_presets() -> None:
+    result = datafog.redact("Email jane@example.com", preset="llm")
+
+    assert "[EMAIL_1]" in result.redacted_text
+
+
+def test_top_level_protect_returns_guardrail() -> None:
+    guardrail = datafog.protect(on_detect="redact")
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        filtered = guardrail.filter("Email jane@example.com")
+
+    assert filtered.redacted_text != "Email jane@example.com"
+    assert not captured
+
+
+def test_legacy_detect_warns_with_replacement() -> None:
+    with pytest.warns(FutureWarning, match=r"Use datafog\.scan\(\) instead"):
+        result = datafog.detect("Email jane@example.com")
+
+    assert result
+
+
+def test_legacy_process_warns_with_replacement() -> None:
+    with pytest.warns(FutureWarning, match=r"datafog\.scan\(\) or datafog\.redact\(\)"):
+        result = datafog.process("Email jane@example.com", anonymize=True)
+
+    assert result["anonymized"] != result["original"]
+
+
+def test_import_does_not_emit_migration_warnings() -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        importlib.reload(datafog)
+
+    assert not [
+        warning
+        for warning in captured
+        if issubclass(warning.category, FutureWarning)
+    ]


### PR DESCRIPTION
## Summary

This PR prepares the v4.4 bridge release before v5.0 and adds contributor workflow scaffolding for the open source project.

It includes:
- Python 3.13 core/CLI metadata and CI/release validation.
- v5-preview top-level APIs: `datafog.scan`, `datafog.redact`, and `datafog.protect`.
- Targeted migration warnings for `datafog.detect` and `datafog.process` with no import-time warnings.
- Pydantic v2 warning cleanup in DataFog-owned models/config.
- v4.4 bridge docs plus v5 product brief, compatibility matrix, and release cut line.
- Contributor docs, PR template, issue templates, and security policy.

## Type

- [ ] Bug fix
- [x] Feature
- [x] Docs
- [x] Tests
- [x] Chore

## Target Branch

- [x] This PR targets `dev`
- [ ] This PR targets `main` for a release/hotfix

## Validation

Commands run:

```bash
.venv313/bin/python -m pytest tests/ -m "not slow" \
  --ignore=tests/test_gliner_annotator.py \
  --ignore=tests/test_image_service.py \
  --ignore=tests/test_ocr_integration.py \
  --ignore=tests/test_spark_integration.py \
  --ignore=tests/test_text_service_integration.py

.venv313/bin/sphinx-build -b html docs docs/_build/html
ruby -e 'require "yaml"; Dir[".github/**/*.yml", ".github/**/*.yaml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'
git diff --check
```

Results:
- Python 3.13 core/CLI suite: 482 passed, 10 skipped, 291 deselected, 19 xfailed.
- Sphinx docs build passed.
- Workflow and issue-template YAML parsed.
- Diff whitespace check passed.

Optional profiles tested:

- [x] core
- [x] cli
- [ ] nlp
- [ ] nlp-advanced
- [ ] ocr
- [ ] distributed

## Notes For Reviewers

The top-level preview APIs default to the lightweight regex engine so the core install stays quiet without optional NLP extras. Users can still opt into `engine="smart"` explicitly.

After this lands, branch rules should be updated to require PRs into `dev`, disable force pushes on `dev`, require at least one approval, require conversation resolution, and align required status-check names with the actual CI matrix jobs.