### PR TITLE
Allow beta release base override

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ on:
         default: false
         type: boolean
       version_override:
-        description: "Override version (e.g. 4.4.0) — stable only"
+        description: "Override stable version or prerelease base (e.g. 4.4.0)"
         required: false
         type: string
 
@@ -214,6 +214,13 @@ jobs:
 
           # Strip any pre-release suffix to get base version
           BASE=$(echo "$CURRENT" | sed -E 's/(a|b)[0-9]+([.][0-9A-Za-z]+)?$//')
+          if [ -n "${{ inputs.version_override }}" ]; then
+            BASE="${{ inputs.version_override }}"
+            if echo "$BASE" | grep -Eq '(a|b)[0-9]+([.][0-9A-Za-z]+)?$'; then
+              echo "version_override must be a stable base version like 4.4.0, not a prerelease"
+              exit 1
+            fi
+          fi
           echo "Base version: $BASE"
 
           if [ "$TYPE" = "alpha" ]; then
@@ -231,12 +238,7 @@ jobs:
             VERSION="${BASE}b${BETA_NUM}"
 
           else
-            # Stable: use override or base version
-            if [ -n "${{ inputs.version_override }}" ]; then
-              VERSION="${{ inputs.version_override }}"
-            else
-              VERSION="$BASE"
-            fi
+            VERSION="$BASE"
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

This updates the release workflow so manual alpha/beta dispatches can use `version_override` as the stable prerelease base.

Why:
- The current dev version is `4.3.0b11`.
- Dispatching a beta without this change would produce `4.3.0b12`.
- For the v4.4 bridge beta, we want to dispatch `release_type=beta` with `version_override=4.4.0`, producing `4.4.0b1`.

## Validation

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML ok"'
BASE=4.4.0; BETA_NUM=1; while git tag -l "vb" | grep -q .; do BETA_NUM=1; done; echo "b"
git diff --check
```

Expected beta version simulation returned `4.4.0b1`.

## Next step after merge

Run the Release workflow manually with:
- `release_type=beta`
- `version_override=4.4.0`
- `dry_run=true` first
- then rerun with `dry_run=false` if the dry run looks good.