### PR TITLE
DFPY-67: Upgrade workflow actions for Node 24

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,12 +13,12 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history for proper comparison
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"
@@ -34,7 +34,7 @@ jobs:
           python -m pytest --collect-only tests/benchmark_text_service.py::test_regex_performance
 
       - name: Restore benchmark data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .benchmarks
           # Updated cache key to reset baseline due to performance optimization changes
@@ -101,7 +101,7 @@ jobs:
           # fi
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"
@@ -40,9 +40,9 @@ jobs:
           - python-version: "3.13"
             install-profile: "nlp-advanced"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -148,7 +148,7 @@ jobs:
           PY
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.xml
           flags: ${{ matrix.install-profile }}-py${{ matrix.python-version }}
@@ -168,9 +168,9 @@ jobs:
           - distributed
           - web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -198,8 +198,8 @@ jobs:
   wheel-size:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,11 @@ jobs:
             BRANCH="dev"
           fi
 
-          echo "release_type=$TYPE" >> $GITHUB_OUTPUT
-          echo "target_branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "release_type=$TYPE" >> "$GITHUB_OUTPUT"
+          echo "target_branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "Release type: $TYPE from $BRANCH"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ steps.resolve.outputs.target_branch }}
@@ -86,15 +86,15 @@ jobs:
           if [ -z "$LAST_TAG" ]; then
             COMMIT_COUNT=$(git rev-list --count --since="7 days ago" HEAD)
           else
-            COMMIT_COUNT=$(git rev-list --count ${LAST_TAG}..HEAD)
+            COMMIT_COUNT=$(git rev-list --count "${LAST_TAG}..HEAD")
           fi
 
           echo "Commits since ${LAST_TAG:-'(none)'}: $COMMIT_COUNT"
 
           if [ "$COMMIT_COUNT" -gt 0 ] || [ "${{ inputs.force_build }}" = "true" ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No changes detected, skipping release"
           fi
 
@@ -107,13 +107,13 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ needs.determine-release.outputs.target_branch }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -145,13 +145,13 @@ jobs:
     if: needs.determine-release.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ needs.determine-release.outputs.target_branch }}
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: "pip"
@@ -177,14 +177,14 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ needs.determine-release.outputs.target_branch }}
           token: ${{ secrets.GH_PAT }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -241,7 +241,7 @@ jobs:
             VERSION="$BASE"
           fi
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
 
           sed -i "s/__version__ = \".*\"/__version__ = \"$VERSION\"/" datafog/__about__.py
@@ -322,7 +322,7 @@ jobs:
     if: needs.determine-release.outputs.release_type != 'stable' && inputs.dry_run != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Prune old alpha releases (keep 7)
         if: needs.determine-release.outputs.release_type == 'alpha'

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ core_deps = [
 
 # Optional heavy dependencies
 nlp_deps = [
+    "click>=8.0,<9.0",
     "spacy>=3.7.0,<4.0",
 ]
 
@@ -57,6 +58,7 @@ web_deps = [
 ]
 
 cli_deps = [
+    "click>=8.0,<9.0",
     "typer>=0.12.0",
     "pydantic-settings>=2.0.0",
 ]

--- a/tests/test_install_profiles.py
+++ b/tests/test_install_profiles.py
@@ -17,10 +17,13 @@ def test_install_profile_import_surface() -> None:
         assert datafog.scan("Email jane@example.com").entities
         assert datafog.redact("Email jane@example.com").redacted_text
     elif profile == "cli":
+        import click  # noqa: F401
+
         from datafog.client import app
 
         assert app is not None
     elif profile == "nlp":
+        import click  # noqa: F401
         import spacy  # noqa: F401
 
         from datafog.models.spacy_nlp import SpacyAnnotator


### PR DESCRIPTION
## Summary

- Upgrade GitHub-hosted workflow actions to Node 24-compatible major lines:
  - `actions/checkout@v6`
  - `actions/setup-python@v6`
  - `actions/cache@v5`
  - `actions/upload-artifact@v7`
  - `codecov/codecov-action@v6`
- Confirm no current workflow references `actions/github-script`.
- Quote release workflow output writes and tag ranges so `actionlint` passes cleanly.
- Make the `click` dependency explicit for fresh `cli`/`nlp` installs after CI exposed that newer `typer` no longer pulls it in transitively.

## Upstream audit

- `actions/setup-python@v6` release notes: upgraded to Node 24 and requires runner `v2.327.1+`.
- `actions/cache@v5` release notes: runs on Node.js 24 and requires runner `v2.327.1+`.
- `actions/checkout@v6` release notes include Node.js 24 support details.
- `codecov/codecov-action@v6` release notes introduce Node 24 support.
- `actions/upload-artifact@v7` is the current major line; workflows use GitHub-hosted `ubuntu-latest`, so no temporary runner workaround was needed.

## Validation

- `actionlint`
- `.venv312/bin/python -m pre_commit run --all-files --show-diff-on-failure`
- `.venv312/bin/python` YAML parse for `.github/workflows/*.yml`
- `DATAFOG_INSTALL_PROFILE=cli DATAFOG_NO_TELEMETRY=1 DO_NOT_TRACK=1 .venv312/bin/python -m pytest tests/test_install_profiles.py -q`
- `DATAFOG_INSTALL_PROFILE=nlp DATAFOG_NO_TELEMETRY=1 DO_NOT_TRACK=1 .venv312/bin/python -m pytest tests/test_install_profiles.py -q`
- Search confirmed no remaining `checkout@v4`, `setup-python@v5`, `cache@v4`, `upload-artifact@v4`, `codecov-action@v5`, or `actions/github-script` references.

Refs DFPY-67