### PR TITLE
docs: add public v5.0.0 roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,4 @@ docs/*
 */**/__pycache__/
 
 notes/benchmarking_notes.md
-Roadmap.md
 notes/*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,37 @@
+# DataFog Roadmap
+
+_Last updated: July 2026 — following the [v4.5.0 stable release](https://github.com/DataFog/datafog-python/releases/tag/v4.5.0)._
+
+DataFog's direction for v5: **the fastest, easiest offline PII firewall for AI apps, logs, and datasets** — no network calls, no model downloads on import, one obvious API.
+
+Independent benchmarking ranks DataFog fastest among Python PII libraries by orders of magnitude. The v5 cycle invests that speed advantage into precision, EU coverage, and a leaner package.
+
+## v5.0.0 themes
+
+### 1. Precision: validators, confidence scores, strictness presets
+
+Speed means nothing if you can't trust the findings. v5 adds a zero-dependency validation pass on every hit (Luhn for credit cards, IBAN mod-97, SSN structure rules, IP plausibility), confidence scores on findings, and strictness presets (`strict` / `balanced` / `lenient`) so you pick the precision/recall tradeoff instead of hand-filtering. We'll publish precision/recall benchmarks alongside the speed benchmarks.
+
+### 2. EU language & entity coverage
+
+v4.5.0 introduced German locale support. v5 generalizes it into a locale pack system — new languages become data plus tests, not code changes — starting with locale-independent EU entities (IBAN, VAT IDs, national ID formats) and expanding across FR/ES/IT/NL/PL through the v5.x line.
+
+### 3. A leaner package
+
+The core install stays pydantic-only and tiny. The heavyweight paths are being cut or spun out: the Donut/transformers OCR path goes away (pytesseract remains), the PySpark wrapper becomes a documented recipe, and legacy duplicate modules are deleted. CI enforces wheel-size and import-time budgets.
+
+### 4. Built for pipelines, not just scripts
+
+The core `scan`/`redact` functions are pure, stateless, and thread-safe, with batch/iterator APIs for high-throughput use. Instead of shipping transport connectors, we're publishing recipes for embedding DataFog in Kafka consumers, Vector/Fluent Bit transforms, and OpenTelemetry collector processors.
+
+### 5. Vault-friendly anonymization
+
+Deterministic tokenization with exportable mappings and format-preserving pseudonymization, so DataFog slots into vault-and-token architectures rather than competing with them.
+
+## API direction
+
+`scan()`, `redact()`, and `protect()` — shipped as previews in v4.5.0 — become the primary documented API in v5.0.0. The legacy `detect()`/`process()` functions keep working as compatibility shims throughout the v5.x line.
+
+## Feedback
+
+Roadmap priorities are shaped by user feedback — open a [GitHub issue](https://github.com/DataFog/datafog-python/issues) or join the [Discord](https://discord.gg/bzDth394R4).


### PR DESCRIPTION
## What this is

A public-facing `ROADMAP.md` at the repo root laying out the v5.0.0 direction, published now that [v4.5.0 is live on PyPI](https://github.com/DataFog/datafog-python/releases/tag/v4.5.0). Internal planning lives in the Linear project ([DataFog Python v5.0.0: Offline PII Firewall for AI Apps](https://linear.app/threadfork/project/datafog-python-v500-offline-pii-firewall-for-ai-apps-78a1550a22f4), epics DFPY-110–115, target July 8); this document is the community-visible summary.

Also removes a stale `Roadmap.md` entry from `.gitignore` (no such private file exists) so the roadmap can live at the root where people expect it.

## The v5 thesis in one line

DataFog is independently benchmarked as the fastest Python PII library by orders of magnitude; v5 invests that speed advantage into **precision, EU coverage, and a leaner package**.

## The five themes

1. **Precision** — checksum validators (Luhn, IBAN mod-97, SSN rules, IP plausibility), confidence scores, and strictness presets. Directly answers the main criticism in third-party evaluations (fast but noisy — false positives like number sequences flagged as IPs).
2. **EU languages** — generalize the German locale support shipped in 4.5.0 into a pattern-pack system; EU-wide entities (IBAN, VAT IDs, national IDs) first, then FR/ES/IT/NL/PL across v5.x.
3. **Leaner package** — drop the Donut/transformers OCR path, spin out the PySpark wrapper, delete legacy duplicate modules; CI-enforced wheel-size and import-time budgets.
4. **Pipeline embeddability** — batch/iterator APIs plus recipes for Kafka, Vector/Fluent Bit, and OpenTelemetry, instead of shipping transport connectors.
5. **Vault-friendly anonymization** — deterministic tokenization with exportable mappings, slotting into vault+token architectures.

## Open questions for discussion

- **Cut line**: proposed v5.0.0 core is themes 1 + 3 + API promotion (scan/redact/protect primary), with themes 2/4/5 landing across v5.x. Is that the right minimal breaking release?
- **Timeline**: July 8 target — realistic for the core cut, or should precision benchmarks gate the stable and push it out?
- **Spin-outs**: do OCR and Spark deserve companion packages (`datafog-ocr`, `datafog-spark`) or just documented recipes?
- **Positioning**: the precision/recall benchmark vs Presidio is a marketing asset as much as an engineering gate — publish alongside the release or before it?

## Test plan

- [ ] Docs-only change; verify `ROADMAP.md` renders correctly on GitHub
- [ ] Confirm no untracked private `Roadmap.md` files exist in contributor clones before the gitignore removal lands