### PR TITLE
ci: make codecov wait for all coverage uploads before computing status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,10 @@
 comment: no
+
+codecov:
+  notify:
+    # The CI test matrix uploads 12 coverage reports (4 Python versions x 3
+    # install profiles). Only the nlp-advanced profile installs litellm, so
+    # the guardrail adapter's lines look uncovered until those uploads land.
+    # Waiting for all builds prevents the recurring interim-red patch status.
+    after_n_builds: 12
+    wait_for_ci: true


### PR DESCRIPTION
Fixes the recurring false-red codecov/patch status (seen on #154, #155, #159, #160): codecov recomputes after every upload, and the early core/nlp profile jobs lack litellm, so the guardrail adapter's lines look uncovered until the four nlp-advanced uploads land. With after_n_builds: 12 (the full test matrix) and wait_for_ci, status is computed once, after all reports arrive.

Note: codecov reads this config from the PR head, so the fix takes effect for PRs branched after this merges.