### PR TITLE
fix: stop no-dash SSN branch matching digit runs inside hex IDs

### DIFF
--- a/datafog/processing/text_processing/regex_annotator/regex_annotator.py
+++ b/datafog/processing/text_processing/regex_annotator/regex_annotator.py
@@ -108,8 +108,10 @@ class RegexAnnotator:
             # a nine-digit run embedded in a longer alphanumeric token (random
             # hex IDs, UUID segments) is not an SSN. The run must not be
             # followed by a letter, and must start either at a non-alphanumeric
-            # boundary or right after a two-letter token prefix (country codes
-            # like "DE123456789" — v4.4.0 parity).
+            # boundary or right after an uppercase "DE" token prefix — the one
+            # letter-prefixed shape pinned for v4.4.0 DE_VAT_ID parity. The
+            # prefix is case-sensitive ((?-i:...)) because lowercase "de" is a
+            # hex byte and would reopen the random-hex-ID false positive.
             "SSN": re.compile(
                 r"""
                 (?:
@@ -117,7 +119,7 @@ class RegexAnnotator:
                     (?!000|666)\d{3}-(?!00)\d{2}-(?!0000)\d{4}
                     (?!\d)
                     |
-                    (?:(?<![0-9A-Za-z])|(?<=\b[A-Za-z]{2}))
+                    (?:(?<![0-9A-Za-z])|(?<=\b(?-i:DE)))
                     (?!000|666)\d{3}(?!00)\d{2}(?!0000)\d{4}
                     (?![0-9A-Za-z])
                 )

--- a/datafog/processing/text_processing/regex_annotator/regex_annotator.py
+++ b/datafog/processing/text_processing/regex_annotator/regex_annotator.py
@@ -104,15 +104,23 @@ class RegexAnnotator:
             # inside a DE_VAT_ID) are resolved by the engine's span-overlap
             # suppression, not here, so default (EN) detection keeps v4.4.0
             # behavior even when German labels are active.
+            # The no-dash branch has stricter boundaries than the dashed one:
+            # a nine-digit run embedded in a longer alphanumeric token (random
+            # hex IDs, UUID segments) is not an SSN. The run must not be
+            # followed by a letter, and must start either at a non-alphanumeric
+            # boundary or right after a two-letter token prefix (country codes
+            # like "DE123456789" — v4.4.0 parity).
             "SSN": re.compile(
                 r"""
-                (?<!\d)
                 (?:
+                    (?<!\d)
                     (?!000|666)\d{3}-(?!00)\d{2}-(?!0000)\d{4}
+                    (?!\d)
                     |
+                    (?:(?<![0-9A-Za-z])|(?<=\b[A-Za-z]{2}))
                     (?!000|666)\d{3}(?!00)\d{2}(?!0000)\d{4}
+                    (?![0-9A-Za-z])
                 )
-                (?!\d)
                 """,
                 re.IGNORECASE | re.MULTILINE | re.VERBOSE,
             ),

--- a/tests/test_regex_annotator.py
+++ b/tests/test_regex_annotator.py
@@ -373,6 +373,29 @@ def test_annotation_result_format():
     assert ssn_spans[0].text == "123-45-6789"
 
 
+def test_ssn_no_dash_not_flagged_inside_alphanumeric_tokens():
+    """Regression guard: bare nine-digit runs embedded in longer
+    alphanumeric tokens (random hex IDs, UUID segments, blob names) must
+    not match SSN. A digit run counts as embedded when the token
+    continues with letters after it, or when it is preceded by a token
+    prefix that is not a bare two-letter country code (see
+    test_ssn_detection_keeps_v44_behavior_for_country_prefixed_digits)."""
+    annotator = RegexAnnotator()
+    for text in (
+        "serverId 3f2a123456789bc is up.",  # letters on both sides
+        "session 9c-3f2a123456789-77 restarted.",  # run ends a hex segment
+        "blob deadbeef123456789cafe stored.",
+        "id a1b2-123456789abc-x9",  # run starts a segment, letters after
+    ):
+        assert annotator.annotate(text)["SSN"] == [], text
+
+
+def test_ssn_no_dash_still_flagged_standalone():
+    """A bare nine-digit number that is its own token must keep matching."""
+    annotator = RegexAnnotator()
+    assert annotator.annotate("Case 219099999 assigned.")["SSN"] == ["219099999"]
+
+
 def test_ssn_detection_keeps_v44_behavior_for_country_prefixed_digits():
     """Regression guard: bare nine-digit runs after a country prefix must
     still match SSN when no locale is configured (v4.4.0 parity). The

--- a/tests/test_regex_annotator.py
+++ b/tests/test_regex_annotator.py
@@ -375,10 +375,9 @@ def test_annotation_result_format():
 
 def test_ssn_no_dash_not_flagged_inside_alphanumeric_tokens():
     """Regression guard: bare nine-digit runs embedded in longer
-    alphanumeric tokens (random hex IDs, UUID segments, blob names) must
-    not match SSN. A digit run counts as embedded when the token
-    continues with letters after it, or when it is preceded by a token
-    prefix that is not a bare two-letter country code (see
+    alphanumeric tokens (random hex IDs, UUID segments, blob names,
+    prefixed record IDs) must not match SSN. The only letter-prefixed
+    shape that still matches is an uppercase "DE" token prefix (see
     test_ssn_detection_keeps_v44_behavior_for_country_prefixed_digits)."""
     annotator = RegexAnnotator()
     for text in (
@@ -386,6 +385,9 @@ def test_ssn_no_dash_not_flagged_inside_alphanumeric_tokens():
         "session 9c-3f2a123456789-77 restarted.",  # run ends a hex segment
         "blob deadbeef123456789cafe stored.",
         "id a1b2-123456789abc-x9",  # run starts a segment, letters after
+        "order ID219099999 shipped.",  # generic two-letter record prefix
+        "ticket PO219099999 open.",
+        "hex de219099999 blob.",  # lowercase "de" is a hex byte, not a country code
     ):
         assert annotator.annotate(text)["SSN"] == [], text
 


### PR DESCRIPTION
## Summary
- The no-dash SSN alternative matched any bare nine-digit run whose neighbors were merely non-digits, so digit runs embedded in longer alphanumeric tokens (random hex IDs, UUID segments) were flagged as SSNs. In the field this made the Claude Code `datafog-hook` PII firewall block an entire preview session whose randomly generated server ID contained such a run.
- Tightened the no-dash branch only: the run must not be followed by a letter, and must start at a non-alphanumeric boundary or immediately after an uppercase `DE` token prefix — the one letter-prefixed shape pinned for v4.4.0 `DE_VAT_ID` parity (`test_ssn_detection_keeps_v44_behavior_for_country_prefixed_digits`). The prefix is case-sensitive because lowercase `de` is a hex byte and would reopen the hex-ID false positive. The dashed branch is unchanged.

## Review notes
An adversarial regex review confirmed: fixed-width lookbehinds are valid, IGNORECASE/VERBOSE interactions are correct, no catastrophic-backtracking risk (tested on 200k-char hex blobs), and the dashed branch is semantically identical to before. Its one HIGH finding — the initial generic two-letter-prefix exception matching `ID...`/`PO...`/lowercase `de...` — is addressed in the second commit by scoping to case-sensitive `DE`.

## Test plan
- [x] New regression test: nine-digit runs inside hex/UUID-style tokens and behind generic two-letter record prefixes (`ID`, `PO`, lowercase `de`) are not flagged
- [x] New test: standalone nine-digit number still flagged
- [x] Existing SSN parametrized cases and v4.4.0 `DE`-prefix regression test pass unchanged
- [x] Full suite: 625 passed; the 4 failures + 1 error also occur on clean `dev` locally (missing spaCy model, environmental)
- [x] isort/black/flake8 clean