### PR TITLE
fix: support Python 3.14 core installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         install-profile: ["core", "nlp", "nlp-advanced"]
+        exclude:
+          - python-version: "3.14"
+            install-profile: nlp
+          - python-version: "3.14"
+            install-profile: nlp-advanced
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -162,6 +167,10 @@ jobs:
           - distributed
           - web
         include:
+          - python-version: "3.14"
+            install-profile: core
+          - python-version: "3.14"
+            install-profile: cli
           - python-version: "3.13"
             install-profile: nlp
           - python-version: "3.13"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
           OMP_NUM_THREADS=4 MKL_NUM_THREADS=4 OPENBLAS_NUM_THREADS=4 python tests/simple_performance_test.py
 
   # ── 3. Build & Publish ────────────────────────────────────────────────
-  python313-core:
+  python314-core:
     needs: determine-release
     if: needs.determine-release.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
@@ -150,10 +150,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.determine-release.outputs.target_branch }}
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install core + CLI dependencies
@@ -161,7 +161,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[test,cli]" -r requirements-test.txt
 
-      - name: Run Python 3.13 core + CLI tests
+      - name: Run Python 3.14 core + CLI tests
         run: |
           pytest tests/ \
             -m "not slow" \
@@ -172,7 +172,7 @@ jobs:
             --ignore=tests/test_text_service_integration.py
 
   publish:
-    needs: [determine-release, test, python313-core]
+    needs: [determine-release, test, python314-core]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+#### Fixed
+
+- Allow installation on Python 3.14 and certify the core SDK and CLI with
+  dedicated CI and release-gate coverage.
+
 ## [2026-07-05]
 
 ### `datafog-python` [4.8.0]

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Python 3.13 support is certified for the core SDK, CLI, `nlp`,
 that is available locally before runtime use. `distributed` and `all` remain
 optional, heavier profiles and are not part of the lightweight core path.
 
+Python 3.14 support is certified for the core SDK and CLI. Optional profiles
+remain dependent on upstream Python 3.14 package availability until they are
+covered by the corresponding CI install-profile checks.
+
 ## Quick Start
 
 ```python

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -22,11 +22,12 @@ final version and release-note alignment in the dedicated release slice.
 Python Environments
 ===================
 
-DataFog currently declares support for Python ``>=3.10,<3.14``. The CI matrix
-tests core, NLP, and NLP-advanced installs on Python 3.10, 3.11, 3.12, and
-3.13. OCR profile smoke checks also run on Python 3.13 with system Tesseract
-installed. Distributed and all-profile installs remain heavier optional
-profiles rather than the lightweight core support claim.
+DataFog declares support for Python ``>=3.10``. The CI matrix tests core, NLP,
+and NLP-advanced installs on Python 3.10, 3.11, 3.12, and 3.13. Python 3.14
+is certified for the core SDK and CLI. OCR profile smoke checks also run on
+Python 3.13 with system Tesseract installed. Optional Python 3.14 profiles
+remain dependent on upstream package availability until their install-profile
+checks are added to CI.
 
 Create one virtual environment per Python version when you need to compare
 profiles locally:

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
     package_data={"datafog": ["py.typed"]},
     install_requires=core_deps,
     extras_require=extras_require,
-    python_requires=">=3.10,<3.14",
+    python_requires=">=3.10",
     entry_points={
         "console_scripts": [
             "datafog=datafog.client:app [cli]",  # Requires cli extra
@@ -133,6 +133,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Text Processing",
         "Topic :: Security",

--- a/setup_lean.py
+++ b/setup_lean.py
@@ -84,7 +84,7 @@ setup(
     packages=find_packages(),
     install_requires=core_deps,
     extras_require=extras_require,
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10",
     entry_points={
         "console_scripts": [
             "datafog=datafog.client:app [cli]",  # Requires cli extra
@@ -98,6 +98,8 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Text Processing",
         "Topic :: Security",

--- a/setup_original.py
+++ b/setup_original.py
@@ -47,7 +47,7 @@ setup(
         "sphinx",
         "cryptography",
     ],
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10",
     entry_points={
         "console_scripts": [
             "datafog=datafog.client:app",
@@ -55,6 +55,8 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## What changed

- Removed the package-wide Python `<3.14` upper bound and declared Python 3.14 in package classifiers.
- Added Python 3.14 core and CLI coverage to CI.
- Made Python 3.14 core and CLI tests a release publishing gate.
- Aligned legacy setup metadata and documented the certified support boundary.

## Why

PyPI metadata for DataFog 4.8.0 rejects Python 3.14 even though the lightweight core runs successfully on that interpreter. The upper bound prevents normal installation before DataFog code is evaluated.

Python 3.14 support is certified for the core SDK and CLI. Optional profiles remain dependent on upstream package availability and are not newly certified by this change.

Closes #171.

## Validation

- Python 3.14.5 release-gate test selection: 597 passed, 12 skipped, 19 expected failures
- Python 3.14 core install-profile smoke test: passed
- Python 3.14 CLI install-profile smoke test: passed
- Built wheel metadata: `Requires-Python: >=3.10` and Python 3.14 classifier present
- Clean Python 3.14 wheel install and scan/redaction smoke test: passed
- `pre-commit run --all-files`: passed