### PR TITLE
docs: add CLA Assistant contributor flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,12 @@ Optional profiles tested:
 - [ ] ocr
 - [ ] distributed
 
+## Contributor Agreement
+
+- [ ] I have reviewed the [DataFog CLA](../CLA.md) and will complete the
+      CLA Assistant check on this pull request. If my employer or another party
+      owns rights in this work, I have obtained permission to contribute it.
+
 ## Notes For Reviewers
 
 Mention API changes, migrations, warnings, or release-note needs.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,105 @@
+# DataFog Individual Contributor License Agreement
+
+Version 1.0
+
+Thank you for your interest in contributing to software and documentation
+managed by DataFog, Inc. ("DataFog"). This Contributor License Agreement
+("Agreement") clarifies the intellectual-property rights granted with your
+contributions. It protects you, DataFog, and the people who use DataFog
+projects. It does not prevent you from using your own contributions for any
+other purpose.
+
+By electronically accepting this Agreement through DataFog's CLA Assistant,
+you agree to the following terms for all past, present, and future
+Contributions that you submit to DataFog.
+
+## 1. Definitions
+
+"You" means the individual accepting this Agreement. If you submit a
+Contribution on behalf of a legal entity, "You" also includes that entity to
+the extent you are authorized to bind it.
+
+"Contribution" means any original work of authorship, including any change or
+addition to an existing work, that you intentionally submit to DataFog for
+inclusion in, or documentation of, a project owned or managed by DataFog.
+
+"Submit" means any electronic, verbal, or written communication sent to
+DataFog or its representatives through a source-code control system, issue
+tracker, code-review system, mailing list, or another communication channel
+used to discuss or improve a DataFog project. A communication that you
+conspicuously mark in writing as "Not a Contribution" is excluded.
+
+"Work" means the DataFog project to which the Contribution is submitted and
+any derivative or collective work based on that project.
+
+## 2. Copyright license
+
+You grant DataFog and recipients of software distributed by DataFog a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute your Contributions and derivative
+works of those Contributions.
+
+## 3. Patent license
+
+You grant DataFog and recipients of software distributed by DataFog a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Work, where the license
+applies only to patent claims licensable by you that are necessarily infringed
+by your Contribution alone or by combination of your Contribution with the
+Work to which it was submitted.
+
+If you or an entity acting on your behalf files patent litigation against
+DataFog or another entity alleging that a Contribution incorporated in the
+Work constitutes direct or contributory patent infringement, the patent
+licenses granted to you under this Agreement for that Work terminate as of the
+date the litigation is filed.
+
+## 4. Your representations
+
+You represent that:
+
+- You are legally entitled to grant the licenses in this Agreement.
+- Each Contribution is your original creation, except for material that you
+  identify in writing together with its source and applicable license.
+- If your employer or another party may own rights in a Contribution, you have
+  received permission to contribute it, that party has waived those rights for
+  the Contribution, or that party has separately granted the necessary rights
+  to DataFog.
+- You will notify DataFog promptly at `sid@datafog.ai` if you become aware
+  that any representation in this Agreement is inaccurate.
+
+## 5. No support obligation
+
+You are not expected to provide support for your Contributions unless you and
+DataFog agree otherwise in writing. Unless required by applicable law or
+agreed in writing, you provide each Contribution "as is," without warranties
+or conditions of any kind, express or implied, including warranties of title,
+non-infringement, merchantability, or fitness for a particular purpose.
+
+## 6. Personal information
+
+DataFog may retain your GitHub identity, acceptance timestamp, Agreement
+version, and the information you provide in the signing form as evidence of
+this Agreement. DataFog will use that information to administer contributions
+and establish the provenance of project intellectual property.
+
+## 7. General
+
+This Agreement is the entire agreement between you and DataFog concerning its
+subject matter and replaces prior understandings about the rights granted with
+your Contributions. If any provision is unenforceable, it will be modified
+only to the minimum extent necessary, and the remaining provisions will
+continue in effect. A failure to enforce a provision is not a waiver of the
+right to enforce it later.
+
+Electronic acceptance through the GitHub account authenticated by DataFog's
+CLA Assistant has the same effect as your signature.
+
+---
+
+This Agreement is based in part on the Apache Software Foundation Individual
+Contributor License Agreement and the Harmony Individual Contributor License
+Agreement. The template adaptations are provided under their respective
+licenses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,8 @@ Before requesting review:
 - Keep public API changes explicit in the PR description.
 - Note any optional dependency profile you tested, such as `core`, `nlp`, or
   `nlp-advanced`.
+- Complete the CLA Assistant check. First-time contributors receive a comment
+  on the pull request with a link to review and accept the agreement.
 
 ## Commit Messages
 
@@ -117,9 +119,23 @@ but not required, for example:
 
 ## Legal
 
-By submitting a pull request, you license your contribution under the project
-[license](LICENSE). You also affirm that you authored the contribution or have
-the right to submit it under the project license.
+DataFog requires each contributor to accept the
+[Individual Contributor License Agreement](CLA.md). CLA Assistant handles the
+signature directly from the pull request:
+
+1. Open your pull request against `dev`.
+2. Follow the link in the CLA Assistant comment and sign in with the same
+   GitHub account that authored the commits.
+3. Review the agreement, complete the short signing form, and accept it. The
+   `cla-assistant` check updates automatically; no document upload is needed.
+
+You normally sign once. A new signature is requested only when DataFog updates
+the agreement. If a commit has multiple authors, every human co-author must
+sign. Bot accounts are handled separately by maintainers.
+
+If your employer or another organization may own your work, confirm that you
+are allowed to contribute before signing. Questions can be sent to
+`sid@datafog.ai`.
 
 ## Contributors
 

--- a/docs/cla-assistant-operations.rst
+++ b/docs/cla-assistant-operations.rst
@@ -1,0 +1,106 @@
+========================
+CLA Assistant Operations
+========================
+
+This runbook records the intended production configuration for DataFog's
+self-hosted CLA Assistant. Do not place credentials, private keys, database
+URIs, or exported signature records in this repository.
+
+Production Identity
+===================
+
+* Public URL: ``https://cla.datafog.ai``
+* GitHub organization: ``DataFog``
+* Initial protected repository: ``DataFog/datafog-python``
+* Agreement: `CLA.md <../CLA.md>`_, version 1.0
+* Administrator allowlist: ``sidmohan0``
+
+The service runs separately from the static ``datafog.ai`` landing page. The
+``cla.datafog.ai`` DNS record points at the production CLA service without
+changing the apex or ``www`` landing-page records.
+
+GitHub Configuration
+====================
+
+The production instance uses both a GitHub OAuth App for interactive login and
+a GitHub App for repository installation and webhooks.
+
+OAuth App:
+
+* Homepage URL: ``https://cla.datafog.ai``
+* Authorization callback URL:
+  ``https://cla.datafog.ai/auth/github/callback``
+
+GitHub App:
+
+* Homepage URL: ``https://cla.datafog.ai``
+* Callback URL: ``https://cla.datafog.ai/auth/github/app-callback``
+* Webhook URL: ``https://cla.datafog.ai/github/webhooks``
+* Install only on the repositories that require the CLA check.
+* Grant only the repository permissions required by the upstream CLA Assistant
+  release. Re-check the upstream documentation before expanding permissions.
+
+The app secrets and private key belong in the hosting provider's secret store.
+Rotate a credential immediately if it appears in logs, shell history, a pull
+request, or a repository file.
+
+Agreement Linkage
+=================
+
+The CLA Assistant record must point to an immutable, reviewable copy of
+``CLA.md``. The public repository copy is the canonical text. If the
+application requires a GitHub Gist, keep the Gist byte-for-byte identical to
+``CLA.md`` and record the source commit in the Gist description.
+
+The signing form should request only:
+
+* Full legal name (required)
+* Email address (required, prefilled from GitHub when available)
+* Signing capacity: individual or on behalf of an organization (required)
+* Organization name (only when signing for an organization)
+* Confirmation that the signer has authority to submit the contribution
+  (required)
+
+Avoid collecting postal addresses, phone numbers, or other information that is
+not needed to establish the agreement.
+
+Merge Protection
+================
+
+After one test pull request completes the signing flow:
+
+#. Add the CLA Assistant status to the ``dev`` branch's required checks.
+#. Add the same check to ``main`` if pull requests can target ``main``
+   directly.
+#. Confirm that unsigned, signed, multi-author, and approved bot pull requests
+   produce the expected result.
+#. Do not merge by bypassing the check except during a documented service
+   incident.
+
+Dependabot and other approved bots cannot sign. Add bot identities through the
+CLA Assistant administration UI; never import a human contributor as signed
+without evidence of acceptance.
+
+Updating The Agreement
+======================
+
+Treat any text change as a new agreement version:
+
+#. Obtain legal review of the proposed change.
+#. Merge the reviewed ``CLA.md`` update.
+#. Update the CLA Assistant source to the exact merged text.
+#. Verify that the application requests a new signature when required.
+#. Export and securely archive the prior version's signature list before the
+   new version becomes active.
+
+Backup And Incident Response
+============================
+
+* Back up the database on a schedule appropriate for legal records and test a
+  restore at least quarterly.
+* Export the signature list after every agreement-version change and before a
+  hosting migration.
+* Monitor the public health endpoint, GitHub webhook deliveries, database
+  availability, and TLS certificate expiration.
+* If the service is unavailable, keep the required check enabled and pause
+  merges rather than silently accepting unsigned contributions.

--- a/docs/cla-assistant-operations.rst
+++ b/docs/cla-assistant-operations.rst
@@ -2,105 +2,111 @@
 CLA Assistant Operations
 ========================
 
-This runbook records the intended production configuration for DataFog's
-self-hosted CLA Assistant. Do not place credentials, private keys, database
-URIs, or exported signature records in this repository.
+This runbook records DataFog's production CLA Assistant configuration. Do not
+place exported signature records or other contributor personal information in
+this repository.
 
-Production Identity
-===================
+Production Configuration
+========================
 
-* Public URL: ``https://cla.datafog.ai``
+* Branded entry point: ``https://cla.datafog.ai``
+* Hosted service: ``https://cla-assistant.io``
 * GitHub organization: ``DataFog``
-* Initial protected repository: ``DataFog/datafog-python``
+* Protected repository: ``DataFog/datafog-python``
 * Agreement: `CLA.md <../CLA.md>`_, version 1.0
-* Administrator allowlist: ``sidmohan0``
+* Agreement Gist:
+  ``https://gist.github.com/sidmohan0/c7f98b0c28a9d827c0a1a570102e0b89``
+* Required GitHub status context: ``license/cla``
 
-The service runs separately from the static ``datafog.ai`` landing page. The
-``cla.datafog.ai`` DNS record points at the production CLA service without
-changing the apex or ``www`` landing-page records.
+SAP's managed CLA Assistant deployment handles GitHub authentication, webhook
+processing, and signature storage. DataFog does not operate a separate CLA
+Assistant application or database.
 
-GitHub Configuration
-====================
+The branded entry point is a redirect-only Vercel project named
+``datafog-cla-redirect``. The ``cla.datafog.ai`` DNS record is a DNS-only CNAME
+to ``e2c831ea94af969f.vercel-dns-016.com``. It must redirect every path to
+``https://cla-assistant.io/DataFog/datafog-python`` without changing the apex
+or ``www`` landing-page records.
 
-The production instance uses both a GitHub OAuth App for interactive login and
-a GitHub App for repository installation and webhooks.
+Agreement And Signing Form
+==========================
 
-OAuth App:
+The repository ``CLA.md`` file is the canonical agreement. CLA Assistant reads
+an unlisted GitHub Gist containing two files:
 
-* Homepage URL: ``https://cla.datafog.ai``
-* Authorization callback URL:
-  ``https://cla.datafog.ai/auth/github/callback``
+* ``DataFog-CLA.md`` must remain byte-for-byte identical to ``CLA.md``.
+* ``metadata`` defines the contributor form fields.
 
-GitHub App:
+The signing form requests only:
 
-* Homepage URL: ``https://cla.datafog.ai``
-* Callback URL: ``https://cla.datafog.ai/auth/github/app-callback``
-* Webhook URL: ``https://cla.datafog.ai/github/webhooks``
-* Install only on the repositories that require the CLA check.
-* Grant only the repository permissions required by the upstream CLA Assistant
-  release. Re-check the upstream documentation before expanding permissions.
-
-The app secrets and private key belong in the hosting provider's secret store.
-Rotate a credential immediately if it appears in logs, shell history, a pull
-request, or a repository file.
-
-Agreement Linkage
-=================
-
-The CLA Assistant record must point to an immutable, reviewable copy of
-``CLA.md``. The public repository copy is the canonical text. If the
-application requires a GitHub Gist, keep the Gist byte-for-byte identical to
-``CLA.md`` and record the source commit in the Gist description.
-
-The signing form should request only:
-
-* Full legal name (required)
-* Email address (required, prefilled from GitHub when available)
+* Full legal name (required and prefilled from GitHub when available)
+* Email address (required and prefilled from GitHub when available)
 * Signing capacity: individual or on behalf of an organization (required)
-* Organization name (only when signing for an organization)
+* Organization name (optional; used when signing for an organization)
 * Confirmation that the signer has authority to submit the contribution
   (required)
 
 Avoid collecting postal addresses, phone numbers, or other information that is
-not needed to establish the agreement.
+not needed to establish the agreement. Because the Gist is unlisted rather
+than private access-controlled storage, do not put secrets or signature data in
+it.
+
+Contributor Flow
+================
+
+#. A contributor opens a pull request against ``dev``.
+#. CLA Assistant comments with the signing link and sets ``license/cla`` to
+   pending.
+#. The contributor signs in with the GitHub account associated with the pull
+   request, reviews the agreement, completes the form, and selects ``I agree``.
+#. CLA Assistant records the acceptance and changes ``license/cla`` to success.
+#. If a pull request has multiple human authors, every author must sign.
+
+Dependabot and other approved bots cannot sign. Add bot identities through the
+CLA Assistant administration UI; never import a human contributor as signed
+without evidence of acceptance.
 
 Merge Protection
 ================
 
 After one test pull request completes the signing flow:
 
-#. Add the CLA Assistant status to the ``dev`` branch's required checks.
+#. Add ``license/cla`` to the required checks for the ``dev`` branch.
 #. Add the same check to ``main`` if pull requests can target ``main``
    directly.
-#. Confirm that unsigned, signed, multi-author, and approved bot pull requests
+#. Confirm that unsigned, signed, multi-author, and approved-bot pull requests
    produce the expected result.
-#. Do not merge by bypassing the check except during a documented service
-   incident.
-
-Dependabot and other approved bots cannot sign. Add bot identities through the
-CLA Assistant administration UI; never import a human contributor as signed
-without evidence of acceptance.
+#. Do not bypass the check except during a documented service incident.
 
 Updating The Agreement
 ======================
 
 Treat any text change as a new agreement version:
 
+#. Export and securely archive the current signature list from the CLA
+   Assistant dashboard.
 #. Obtain legal review of the proposed change.
 #. Merge the reviewed ``CLA.md`` update.
-#. Update the CLA Assistant source to the exact merged text.
-#. Verify that the application requests a new signature when required.
-#. Export and securely archive the prior version's signature list before the
-   new version becomes active.
+#. Replace only the ``DataFog-CLA.md`` Gist file with the exact merged text;
+   retain the ``metadata`` file unless the form is intentionally changing.
+#. Verify that CLA Assistant displays the new version and requests a new
+   signature when required.
 
-Backup And Incident Response
-============================
+Operations And Incident Response
+================================
 
-* Back up the database on a schedule appropriate for legal records and test a
-  restore at least quarterly.
-* Export the signature list after every agreement-version change and before a
-  hosting migration.
-* Monitor the public health endpoint, GitHub webhook deliveries, database
-  availability, and TLS certificate expiration.
-* If the service is unavailable, keep the required check enabled and pause
-  merges rather than silently accepting unsigned contributions.
+* Restrict CLA Assistant administration to DataFog maintainers who need it.
+* Export signature records after an agreement-version change and before any
+  service migration; store exports in DataFog's access-controlled records
+  system, not GitHub.
+* Monitor the hosted service, the ``license/cla`` check, the branded redirect,
+  and TLS certificate health.
+* If the hosted service is unavailable, keep the required check enabled and
+  pause merges rather than silently accepting unsigned contributions.
+* Review the managed service's terms and privacy policy when DataFog changes
+  the personal information collected in the signing form.
+
+Self-hosting is not the current production architecture. Re-evaluate it only
+if DataFog needs controls the managed service cannot provide and after the
+upstream runtime, dependencies, database, backups, security updates, and
+on-call ownership have been reviewed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Contributing
    :caption: Contributing
 
    contributing
+   cla-assistant-operations
    v45-release-readiness
    live-module-map
 


### PR DESCRIPTION
## Summary

- add DataFog Individual Contributor License Agreement v1.0
- explain the first-time signing flow in the contribution guide and PR template
- document the intended CLA Assistant configuration, versioning, bot handling, backups, and merge protection
- index the operations runbook in the contributor docs

## Hosting decision

Use SAP's maintained `cla-assistant.io` service and reserve `cla.datafog.ai` as the branded contributor entry point. The upstream self-hosted image remains pinned to Node 16, so operating it as a new public legal-record service would add avoidable security and maintenance risk.

## Validation

- `pre-commit run --files CLA.md CONTRIBUTING.md .github/PULL_REQUEST_TEMPLATE.md docs/cla-assistant-operations.rst docs/index.rst --show-diff-on-failure`
- `git diff --check`
- Sphinx build not run locally because Sphinx is not installed in the current environment

## Review note

The CLA is adapted from the Apache ICLA and Harmony Individual CLA templates. It should receive legal review before this draft is marked ready or enforced as a required check.